### PR TITLE
Add Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ os: linux
 dist: bionic
 language: php
 php:
-  - 7.0
-  - 7.1
   - 7.2
   - 7.3
   - 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+os: linux
+dist: bionic
+language: php
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
+  - 8.0
+  - 8.1
+cache:
+  directories:
+  - "$HOME/.composer/cache"
+before_install:
+- phpenv config-rm xdebug.ini
+install:
+- composer install
+script:
+- composer run all-checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - 8.0
-  - 8.1
 cache:
   directories:
   - "$HOME/.composer/cache"

--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,13 @@
         "squizlabs/php_codesniffer" : "^3.6.2",
         "wp-coding-standards/wpcs": "^2.3.0",
         "automattic/vipwpcs": "^2.3.3",
-        "php": ">=7.2"
+        "php": ">=7.2 <8"
     },
     "require-dev": {
-        "phpcsstandards/phpcsdevtools": "1.1.0",
-        "phpcompatibility/php-compatibility": "9.3.5",
-        "php-parallel-lint/php-parallel-lint": "1.3.2",
-        "phpunit/phpunit": "7.5.20"
+        "phpcsstandards/phpcsdevtools": "^1.1.0",
+        "phpcompatibility/php-compatibility": "^9.3.5",
+        "php-parallel-lint/php-parallel-lint": "^1.3.2",
+        "phpunit/phpunit": "^7.5.20"
     },
 	"config": {
 		"allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "squizlabs/php_codesniffer" : "^3.6.2",
         "wp-coding-standards/wpcs": "^2.3.0",
         "automattic/vipwpcs": "^2.3.3",
-        "php": ">=7.0"
+        "php": ">=7.2"
     },
     "require-dev": {
         "phpcsstandards/phpcsdevtools": "1.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c4bf648a6e2c23b9f18c3c507f444dd",
+    "content-hash": "e8a1c33e2adce70857abfcfbd0c0a7eb",
     "packages": [
         {
             "name": "automattic/vipwpcs",
@@ -2180,7 +2180,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0"
+        "php": ">=7.2 <8"
     },
     "platform-dev": [],
     "plugin-api-version": "2.1.0"


### PR DESCRIPTION
## Description
Add Travis CI support; it will run `composer run all-checks` for the following PHP versions:
- 7.2
- 7.3
- 7.4

These are the only PHP versions this repository currently supports, due to dependency PHP requirements.

## Changelog
* Add Travis CI integration
