### PR TITLE
Add list of files/dirs to ignore when creating archives

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,15 @@
             "email": "jon@bigbite.net"
         }
     ],
+	"archive": {
+		"exclude": [
+			"/.editorconfig",
+			"/.gitignore",
+			"/.phpcs.xml.dist",
+			"/Tests",
+			"/phpunit.xml.dist"
+		]
+	},
 	"scripts-descriptions": {
 		"lint": "Runs PHP syntax error checks",
 		"phpcs": "Runs PHP coding standard checks",


### PR DESCRIPTION
## Description
Add list of dev directories/files to composer's `archive.exclude` property.

## Changelog
* Add list of files/dirs to ignore when creating archives
