### PR TITLE
Add Sniffing support for interfaces and traits

### DIFF
--- a/BigBite/Docs/Files/FileNameStandard.xml
+++ b/BigBite/Docs/Files/FileNameStandard.xml
@@ -1,9 +1,11 @@
 <documentation title="File Names">
   <standard>
   <![CDATA[
-  Files containing classes should be prefixed with "class-" or "abstract-class", and be named
-  as the class name in lower-kebab-case. For example:
-  the file name for abstract class My_Class_Name {} would be "abstract-class-my-class-name.php".
+  Files containing classes, interfaces, or traits should be prefixed appropriately - prefixed with the type, and then lower-kebab-case matching the name of the type. Examples:
+  - trait My_Trait {} => trait-my-trait.php
+  - interface My_Interface {} => interface-my-interface.php
+  - class My_Class {} => class-my-class.php
+  - abstract class My_Abstract_Class {} => abstract-class-my-abstract-class.php
   ]]>
   </standard>
 </documentation>

--- a/BigBite/Sniffs/Files/FileNameSniff.php
+++ b/BigBite/Sniffs/Files/FileNameSniff.php
@@ -59,36 +59,13 @@ class FileNameSniff extends WPFileNameSniff {
 
 		unset( $expected );
 
-		/*
-		 * Check files containing a class for the "class-" prefix and that the rest of
-		 * the file name reflects the class name. Accounts for abstract classes.
-		 */
-		if ( true === $this->strict_class_file_names ) {
-			$has_class = $this->phpcsFile->findNext( \T_CLASS, $stackPtr );
-
-			if ( false !== $has_class && false === $this->is_test_class( $has_class ) ) {
-				$is_abstract = $this->phpcsFile->findPrevious( \T_ABSTRACT, $has_class );
-				$class_name  = $this->phpcsFile->getDeclarationName( $has_class );
-
-				if ( is_null( $class_name ) ) {
-					$class_name = 'anonymous';
-				}
-
-				$expected    = 'class-' . $this->kebab( $class_name );
-				$err_message = 'Class file names should be based on the class name with "class-" prepended. Expected %s, but found %s.';
-
-				if ( $is_abstract ) {
-					$expected    = 'abstract-' . $expected;
-					$err_message = 'Abstract class file names should be based on the class name with "abstract-class-" prepended. Expected %s, but found %s.';
-				}
-
-				if ( substr( $fileName, 0, -4 ) !== $expected ) {
-					$this->phpcsFile->addError( $err_message, 0, 'InvalidClassFileName', [ $expected . '.php', $fileName ] );
-				}
-
-				unset( $expected );
-			}
+		if ( true !== $this->strict_class_file_names ) {
+			return ( $this->phpcsFile->numTokens + 1 );
 		}
+
+		$this->check_maybe_class( $stackPtr, $fileName );
+		$this->check_maybe_trait( $stackPtr, $fileName );
+		$this->check_maybe_interface( $stackPtr, $fileName );
 
 		// Only run this sniff once per file, no need to run it again.
 		return ( $this->phpcsFile->numTokens + 1 );
@@ -127,6 +104,99 @@ class FileNameSniff extends WPFileNameSniff {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Check files containing a class for the "class-" prefix,
+	 * and that the rest of the file name reflects the class name.
+	 * Accounts for abstract classes.
+	 *
+	 * @param mixed  $stackPtr the token stack
+	 * @param string $fileName the name of the file
+	 *
+	 * @return void
+	 */
+	protected function check_maybe_class( $stackPtr, $fileName ) {
+		$has_class = $this->phpcsFile->findNext( \T_CLASS, $stackPtr );
+
+		if ( false === $has_class || false !== $this->is_test_class( $has_class ) ) {
+			return;
+		}
+
+		$is_abstract = $this->phpcsFile->findPrevious( \T_ABSTRACT, $has_class );
+		$class_name  = $this->phpcsFile->getDeclarationName( $has_class );
+
+		if ( is_null( $class_name ) ) {
+			$class_name = 'anonymous';
+		}
+
+		$expected    = 'class-' . $this->kebab( $class_name );
+		$err_message = 'Class file names should be based on the class name with "class-" prepended. Expected %s, but found %s.';
+
+		if ( $is_abstract ) {
+			$expected    = 'abstract-' . $expected;
+			$err_message = 'Abstract class file names should be based on the class name with "abstract-class-" prepended. Expected %s, but found %s.';
+		}
+
+		if ( substr( $fileName, 0, -4 ) === $expected ) {
+			return;
+		}
+
+		$this->phpcsFile->addError( $err_message, 0, 'InvalidClassFileName', [ $expected . '.php', $fileName ] );
+	}
+
+	/**
+	 * Check files containing a trait for the "trait-" prefix,
+	 * and that the rest of the file name reflects the trait name.
+	 *
+	 * @param mixed  $stackPtr the token stack
+	 * @param string $fileName the name of the file
+	 *
+	 * @return void
+	 */
+	protected function check_maybe_trait( $stackPtr, $fileName ) {
+		$has_trait = $this->phpcsFile->findNext( \T_TRAIT, $stackPtr );
+
+		if ( false === $has_trait || false !== $this->is_test_class( $has_trait ) ) {
+			return;
+		}
+
+		$trait_name  = $this->phpcsFile->getDeclarationName( $has_trait );
+		$expected    = 'trait-' . $this->kebab( $trait_name );
+		$err_message = 'Trait file names should be based on the class name with "trait-" prepended. Expected %s, but found %s.';
+
+		if ( substr( $fileName, 0, -4 ) === $expected ) {
+			return;
+		}
+
+		$this->phpcsFile->addError( $err_message, 0, 'InvalidTraitFileName', [ $expected . '.php', $fileName ] );
+	}
+
+	/**
+	 * Check files containing an interface for the "interface-" prefix,
+	 * and that the rest of the file name reflects the interface name.
+	 *
+	 * @param mixed  $stackPtr the token stack
+	 * @param string $fileName the name of the file
+	 *
+	 * @return void
+	 */
+	protected function check_maybe_interface( $stackPtr, $fileName ) {
+		$has_interface = $this->phpcsFile->findNext( \T_INTERFACE, $stackPtr );
+
+		if ( false === $has_interface || false !== $this->is_test_class( $has_interface ) ) {
+			return;
+		}
+
+		$interface_name = $this->phpcsFile->getDeclarationName( $has_interface );
+		$expected       = 'interface-' . $this->kebab( $interface_name );
+		$err_message    = 'Interface file names should be based on the interface name with "interface-" prepended. Expected %s, but found %s.';
+
+		if ( substr( $fileName, 0, -4 ) === $expected ) {
+			return;
+		}
+
+		$this->phpcsFile->addError( $err_message, 0, 'InvalidInterfaceFileName', [ $expected . '.php', $fileName ] );
 	}
 
 	/**

--- a/BigBite/Tests/Files/FileNameUnitTest.php
+++ b/BigBite/Tests/Files/FileNameUnitTest.php
@@ -36,12 +36,18 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 		'SomeView.inc'                               => 1,
 
 		// Class file names.
-		'my-class.inc'                               => 1,
 		'my-abstract-class.inc'                      => 1,
-		'class-different-class.inc'                  => 1,
+		'my-class.inc'                               => 1,
+		'my-interface.inc'                           => 1,
+		'my-trait.inc'                               => 1,
 		'abstract-class-different-class.inc'         => 1,
-		'ClassMyClass.inc'                           => 2,
+		'class-different-class.inc'                  => 1,
+		'interface-different-interface.inc'          => 1,
+		'trait-different-trait.inc'                  => 1,
 		'AbstractClassMyClass.inc'                   => 2,
+		'ClassMyClass.inc'                           => 2,
+		'InterfaceMyInterface.inc'                   => 2,
+		'TraitMyTrait.inc'                           => 2,
 
 		// Theme specific exceptions in a non-theme context.
 		'single-my_post_type.inc'                    => 1,
@@ -52,8 +58,10 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 		 */
 
 		// Non-strict class names still have to comply with lowercase hyphenated.
-		'ClassNonStrictClass.inc'                    => 1,
 		'AbstractClassNonStrictClass.inc'            => 1,
+		'ClassNonStrictClass.inc'                    => 1,
+		'InterfaceNonStrictClass.inc'                => 1,
+		'TraitNonStrictClass.inc'                    => 1,
 
 		/*
 		 * In /FileNameUnitTests/PHPCSAnnotations.

--- a/BigBite/Tests/Files/FileNameUnitTests/InterfaceMyInterface.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/InterfaceMyInterface.inc
@@ -1,0 +1,3 @@
+<?php
+
+interface My_Interface {}

--- a/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/InterfaceNonStrictClass.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/InterfaceNonStrictClass.inc
@@ -1,0 +1,8 @@
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set BigBite.Files.FileName strict_class_file_names false
+
+<?php
+
+interface Non_Strict_Interface {}
+
+// phpcs:set BigBite.Files.FileName strict_class_file_names true

--- a/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/TraitNonStrictClass.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/TraitNonStrictClass.inc
@@ -1,0 +1,8 @@
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set BigBite.Files.FileName strict_class_file_names false
+
+<?php
+
+trait Non_Strict_Trait {}
+
+// phpcs:set BigBite.Files.FileName strict_class_file_names true

--- a/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-interface.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-interface.inc
@@ -1,0 +1,8 @@
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set BigBite.Files.FileName strict_class_file_names false
+
+<?php
+
+interface Non_Strict_Interface {}
+
+// phpcs:set BigBite.Files.FileName strict_class_file_names true

--- a/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-trait.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-trait.inc
@@ -1,0 +1,8 @@
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set BigBite.Files.FileName strict_class_file_names false
+
+<?php
+
+trait Non_Strict_Trait {}
+
+// phpcs:set BigBite.Files.FileName strict_class_file_names true

--- a/BigBite/Tests/Files/FileNameUnitTests/TraitMyTrait.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/TraitMyTrait.inc
@@ -1,0 +1,3 @@
+<?php
+
+trait My_Trait {}

--- a/BigBite/Tests/Files/FileNameUnitTests/interface-different-interface.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/interface-different-interface.inc
@@ -1,0 +1,3 @@
+<?php
+
+interface Not_My_Interface {}

--- a/BigBite/Tests/Files/FileNameUnitTests/interface-my-interface.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/interface-my-interface.inc
@@ -1,0 +1,3 @@
+<?php
+
+interface My_Interface {}

--- a/BigBite/Tests/Files/FileNameUnitTests/my-interface.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/my-interface.inc
@@ -1,0 +1,3 @@
+<?php
+
+interface My_Interface {}

--- a/BigBite/Tests/Files/FileNameUnitTests/my-trait.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/my-trait.inc
@@ -1,0 +1,3 @@
+<?php
+
+trait My_Trait {}

--- a/BigBite/Tests/Files/FileNameUnitTests/trait-different-trait.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/trait-different-trait.inc
@@ -1,0 +1,3 @@
+<?php
+
+trait Not_My_Trait {}

--- a/BigBite/Tests/Files/FileNameUnitTests/trait-my-trait.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/trait-my-trait.inc
@@ -1,0 +1,3 @@
+<?php
+
+trait My_Trait {}


### PR DESCRIPTION
## Description
Implement support for sniffing interface and trait names in the same manner as classes/abstract classes

## Changelog
* Add Sniffing support for interfaces and traits

## Types of changes:
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] All checks pass when running `composer run all-checks`.
