### PR TITLE
Remove index.php from file exclusions

### DIFF
--- a/BigBite/ruleset.xml
+++ b/BigBite/ruleset.xml
@@ -25,7 +25,6 @@
   <exclude-pattern>*/wp-settings.php</exclude-pattern>
   <exclude-pattern>*/wp-signup.php</exclude-pattern>
   <exclude-pattern>*/wp-trackback.php</exclude-pattern>
-  <exclude-pattern>*/index.php</exclude-pattern>
   <exclude-pattern>*/mu-plugins/*</exclude-pattern>
   <exclude-pattern>*/private/*</exclude-pattern>
   <exclude-pattern>*/upgrade/*</exclude-pattern>


### PR DESCRIPTION
## Description
Fixes #17 - index.php files being ignored

## Changelog
* Remove index.php from file exclusions in ruleset

## Types of changes:
- [x] Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] All checks pass when running `composer run all-checks.
