### PR TITLE
Allow PHPCS to cache its report results

### DIFF
--- a/BigBite/ruleset.xml
+++ b/BigBite/ruleset.xml
@@ -8,6 +8,7 @@
   <arg name="report" value="full" />
   <arg name="report-width" value="150" />
   <arg name="tab-width" value="4" />
+  <arg name="cache" />
   <arg value="qs" />
 
   <exclude-pattern>*/.git/*</exclude-pattern>


### PR DESCRIPTION
Uses system temp directory if none specified, so there's no need to worry about .gitignore.
Although it has no impact on initial runs, it *significantly* improves the speed of subsequent runs.

## Changelog
* Allow PHPCS to cache its report results

## Types of changes:
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [x] All checks pass when running `composer run all-checks.
