### PR TITLE
Add circleci config with slack notification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - run:
           command: |
-            curl -X POST -H 'Content-type: application/json' --data '{"text":"New PHPCS Config Release","blocks":[{"type":"header","text":{"type":"plain_text","text":"New  PHPCS Config Release"}},{"type":"section","fields":[{"type":"mrkdwn","text":"*Version:* <https://github.com/'${CIRCLE_PROJECT_USERNAME}'/'${CIRCLE_PROJECT_REPONAME}'/releases/tag/'${CIRCLE_TAG}'|'${CIRCLE_TAG}'>"},{"type":"mrkdwn","text":"<https://github.com/'${CIRCLE_PROJECT_USERNAME}'/'${CIRCLE_PROJECT_REPONAME}'/issues|Issues> *|* <https://github.com/'${CIRCLE_PROJECT_USERNAME}'/'${CIRCLE_PROJECT_REPONAME}'/pulls|Pull Requests>"}]}]}' ${SLACK_WEBHOOK}
+            curl -X POST -H 'Content-type: application/json' --data '{"text":"New PHPCS Config Release","blocks":[{"type":"header","text":{"type":"plain_text","text":"New PHPCS Config Release"}},{"type":"section","fields":[{"type":"mrkdwn","text":"*Version:* <https://github.com/'${CIRCLE_PROJECT_USERNAME}'/'${CIRCLE_PROJECT_REPONAME}'/releases/tag/'${CIRCLE_TAG}'|'${CIRCLE_TAG}'>"},{"type":"mrkdwn","text":"<https://github.com/'${CIRCLE_PROJECT_USERNAME}'/'${CIRCLE_PROJECT_REPONAME}'/issues|Issues> *|* <https://github.com/'${CIRCLE_PROJECT_USERNAME}'/'${CIRCLE_PROJECT_REPONAME}'/pulls|Pull Requests>"}]}]}' ${SLACK_WEBHOOK}
           name: Send Slack update to channel
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2.1
+
+orbs:
+  node: circleci/node@4.7.0
+
+jobs:
+  notify_slack:
+    docker:
+      - image: cimg/node:17.2.0
+    steps:
+      - run:
+          command: |
+            curl -X POST -H 'Content-type: application/json' --data '{"text":"New PHPCS Config Release","blocks":[{"type":"header","text":{"type":"plain_text","text":"New Build Tools Release"}},{"type":"section","fields":[{"type":"mrkdwn","text":"*Version:* <https://github.com/'${CIRCLE_PROJECT_USERNAME}'/'${CIRCLE_PROJECT_REPONAME}'/releases/tag/'${CIRCLE_TAG}'|'${CIRCLE_TAG}'>"},{"type":"mrkdwn","text":"<https://github.com/'${CIRCLE_PROJECT_USERNAME}'/'${CIRCLE_PROJECT_REPONAME}'/issues|Issues> *|* <https://github.com/'${CIRCLE_PROJECT_USERNAME}'/'${CIRCLE_PROJECT_REPONAME}'/pulls|Pull Requests>"}]}]}' ${SLACK_WEBHOOK}
+          name: Send Slack update to channel
+
+workflows:
+  run_notify_slack:
+    jobs:
+      - notify_slack:
+          filters:
+            tags:
+              only: /v?[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha).[0-9]+)?/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - run:
           command: |
-            curl -X POST -H 'Content-type: application/json' --data '{"text":"New PHPCS Config Release","blocks":[{"type":"header","text":{"type":"plain_text","text":"New Build Tools Release"}},{"type":"section","fields":[{"type":"mrkdwn","text":"*Version:* <https://github.com/'${CIRCLE_PROJECT_USERNAME}'/'${CIRCLE_PROJECT_REPONAME}'/releases/tag/'${CIRCLE_TAG}'|'${CIRCLE_TAG}'>"},{"type":"mrkdwn","text":"<https://github.com/'${CIRCLE_PROJECT_USERNAME}'/'${CIRCLE_PROJECT_REPONAME}'/issues|Issues> *|* <https://github.com/'${CIRCLE_PROJECT_USERNAME}'/'${CIRCLE_PROJECT_REPONAME}'/pulls|Pull Requests>"}]}]}' ${SLACK_WEBHOOK}
+            curl -X POST -H 'Content-type: application/json' --data '{"text":"New PHPCS Config Release","blocks":[{"type":"header","text":{"type":"plain_text","text":"New  PHPCS Config Release"}},{"type":"section","fields":[{"type":"mrkdwn","text":"*Version:* <https://github.com/'${CIRCLE_PROJECT_USERNAME}'/'${CIRCLE_PROJECT_REPONAME}'/releases/tag/'${CIRCLE_TAG}'|'${CIRCLE_TAG}'>"},{"type":"mrkdwn","text":"<https://github.com/'${CIRCLE_PROJECT_USERNAME}'/'${CIRCLE_PROJECT_REPONAME}'/issues|Issues> *|* <https://github.com/'${CIRCLE_PROJECT_USERNAME}'/'${CIRCLE_PROJECT_REPONAME}'/pulls|Pull Requests>"}]}]}' ${SLACK_WEBHOOK}
           name: Send Slack update to channel
 
 workflows:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To help keep everyone within Big Bite informed of any releases that are happening with PHPCS configs, it might be a good idea to use Slack webhooks to notify specific channels of any releases. This has already been added to the [Build Tools repo](https://github.com/bigbite/build-tools).

CircleCI will need enabling on the repo and `SLACK_WEBHOOK` needs to be set in the environment variables - I can provide the webhook url, just reach out.

## Changelog
* Adds a CircleCI config to the project to allow any releases to notify Big Bite slack channels.

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] All checks pass when running `composer run all-checks.
