### PR TITLE
v2.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,33 @@ jobs:
       - checkout
       - run:
           command: |
-            composer install --ignore-platform-reqs
+            composer install --ignore-platform-req=php
+          name: Composer install
+      - run:
+          command: |
+            composer run all-checks-strict
+          name: Run all checks
+  php_81_tests:
+    docker:
+      - image: cimg/php:8.1
+    steps:
+      - checkout
+      - run:
+          command: |
+            composer install --ignore-platform-req=php
+          name: Composer install
+      - run:
+          command: |
+            composer run all-checks-strict
+          name: Run all checks
+  php_82_tests:
+    docker:
+      - image: cimg/php:8.2
+    steps:
+      - checkout
+      - run:
+          command: |
+            composer install --ignore-platform-req=php
           name: Composer install
       - run:
           command: |
@@ -41,6 +67,8 @@ workflows:
     jobs:
       - php_74_tests
       - php_80_tests
+      - php_81_tests
+      - php_82_tests
   run_notify_slack:
     jobs:
       - notify_slack:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,33 +21,7 @@ jobs:
       - checkout
       - run:
           command: |
-            composer install --ignore-platform-req=php
-          name: Composer install
-      - run:
-          command: |
-            composer run all-checks-strict
-          name: Run all checks
-  php_81_tests:
-    docker:
-      - image: cimg/php:8.1
-    steps:
-      - checkout
-      - run:
-          command: |
-            composer install --ignore-platform-req=php
-          name: Composer install
-      - run:
-          command: |
-            composer run all-checks-strict
-          name: Run all checks
-  php_82_tests:
-    docker:
-      - image: cimg/php:8.2
-    steps:
-      - checkout
-      - run:
-          command: |
-            composer install --ignore-platform-req=php
+            composer install --ignore-platform-reqs
           name: Composer install
       - run:
           command: |
@@ -67,8 +41,6 @@ workflows:
     jobs:
       - php_74_tests
       - php_80_tests
-      - php_81_tests
-      - php_82_tests
   run_notify_slack:
     jobs:
       - notify_slack:

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,43 +1,97 @@
 <?xml version="1.0"?>
-<ruleset name="Big Bite CS" namespace="BigBite">
-  <description>The Coding Standard for the Big Bite Coding Standards.</description>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Big Bite Coding Standards' Coding Standard" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+	<description>The Coding standard for the Big Bite Coding Standards itself.</description>
+  <!-- Copied from https://github.com/WordPress/WordPress-Coding-Standards/blob/3.0.0/.phpcs.xml.dist -->
 
-  <file>.</file>
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-Ruleset
+	#############################################################################
+	-->
 
-  <config name="encoding" value="utf-8" />
-  <config name="testVersion" value="7.0-" />
+	<file>.</file>
 
-  <arg name="basepath" value="." />
-  <arg name="extensions" value="php" />
-  <arg name="tab-width" value="4" />
-  <arg value="qs" />
+	<!-- Exclude Composer vendor directory. -->
+	<exclude-pattern>*/vendor/*</exclude-pattern>
 
-  <!-- Exclude Composer vendor directory. -->
-  <exclude-pattern>*/vendor/*</exclude-pattern>
+	<!-- Only check PHP files. -->
+	<arg name="extensions" value="php"/>
 
-  <rule ref="BigBite">
-    <exclude name="BigBite.Files.FileName" />
-    <exclude name="WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition" />
-    <exclude name="WordPress.NamingConventions.ValidVariableName" />
-  </rule>
+	<!-- Show progress, show the error codes for each message (source). -->
+	<arg value="ps"/>
 
-  <!-- Enforce PSR1 compatible namespaces. -->
-  <rule ref="PSR1.Classes.ClassDeclaration" />
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="."/>
 
-  <!-- prevent empty lines between method bodies and closing braces -->
-  <rule ref="PSR2.Methods.FunctionClosingBrace" />
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
 
-  <!-- Check code for cross-version PHP compatibility. -->
-  <rule ref="PHPCompatibility">
-    <!-- Exclude PHP constants back-filled by PHPCS. -->
-    <exclude name="PHPCompatibility.Constants.NewConstants.t_finallyFound" />
-    <exclude name="PHPCompatibility.Constants.NewConstants.t_yieldFound" />
-    <exclude name="PHPCompatibility.Constants.NewConstants.t_ellipsisFound" />
-    <exclude name="PHPCompatibility.Constants.NewConstants.t_powFound" />
-    <exclude name="PHPCompatibility.Constants.NewConstants.t_pow_equalFound" />
-    <exclude name="PHPCompatibility.Constants.NewConstants.t_spaceshipFound" />
-    <exclude name="PHPCompatibility.Constants.NewConstants.t_coalesceFound" />
-    <exclude name="PHPCompatibility.Constants.NewConstants.t_coalesce_equalFound" />
-    <exclude name="PHPCompatibility.Constants.NewConstants.t_yield_fromFound" />
-  </rule>
+	<!--
+	#############################################################################
+	SET UP THE RULESETS
+	#############################################################################
+	-->
+
+	<rule ref="WordPress">
+		<!-- This project needs to comply with naming standards from PHPCS, not WP. -->
+		<exclude name="WordPress.Files.FileName"/>
+		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
+
+		<!-- While conditions with assignments are a typical way to walk the token stream. -->
+		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition"/>
+
+		<!-- The code in this project is run in the context of PHPCS, not WP. -->
+		<exclude name="WordPress.DateTime"/>
+		<exclude name="WordPress.DB"/>
+		<exclude name="WordPress.Security"/>
+		<exclude name="WordPress.WP"/>
+
+		<!-- Linting is done in a separate CI job, no need to duplicate it. -->
+		<exclude name="Generic.PHP.Syntax"/>
+
+		<!-- WordPressCS still has a PHP 5.4 minimum. -->
+		<exclude name="Modernize.FunctionCalls.Dirname"/>
+	</rule>
+
+	<!-- Check code for cross-version PHP compatibility. -->
+	<config name="testVersion" value="5.4-"/>
+	<rule ref="PHPCompatibility">
+		<!-- Exclude PHP constants back-filled by PHPCS. -->
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_finallyFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_yieldFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_ellipsisFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_powFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_pow_equalFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_spaceshipFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_coalesceFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_coalesce_equalFound"/>
+		<exclude name="PHPCompatibility.Constants.NewConstants.t_yield_fromFound"/>
+	</rule>
+
+	<!-- Enforce PSR1 compatible namespaces. -->
+	<rule ref="PSR1.Classes.ClassDeclaration"/>
+
+	<!-- Enforce that classes are abstract or final. -->
+	<rule ref="Universal.Classes.RequireFinalClass">
+		<!-- ... with the exception of four sniffs which are known to be extended by external standards. -->
+		<exclude-pattern>/WordPress/Sniffs/NamingConventions/ValidHookNameSniff\.php$</exclude-pattern>
+		<exclude-pattern>/WordPress/Sniffs/Security/(EscapeOutput|NonceVerification|ValidatedSanitizedInput)Sniff\.php$</exclude-pattern>
+	</rule>
+
+	<!-- Enforce that methods in traits are always final. -->
+	<rule ref="Universal.FunctionDeclarations.RequireFinalMethodsInTraits"/>
+
+	<!--
+	#############################################################################
+	SNIFF SPECIFIC CONFIGURATION
+	#############################################################################
+	-->
+
+	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
+		<properties>
+			<property name="alignMultilineItems" value="!=100"/>
+			<property name="exact" value="false" phpcs-only="true"/>
+		</properties>
+	</rule>
 </ruleset>

--- a/BigBite/Sniffs/Files/FileNameSniff.php
+++ b/BigBite/Sniffs/Files/FileNameSniff.php
@@ -154,7 +154,10 @@ final class FileNameSniff extends Sniff {
 			return;
 		}
 
-		$class_ptr = $this->phpcsFile->findNext( \T_CLASS, $stack_ptr );
+		$class_ptr     = $this->phpcsFile->findNext( \T_CLASS, $stack_ptr );
+		$trait_ptr     = $this->phpcsFile->findNext( \T_TRAIT, $stack_ptr );
+		$interface_ptr = $this->phpcsFile->findNext( \T_INTERFACE, $stack_ptr );
+
 		if ( false !== $class_ptr && $this->is_test_class( $this->phpcsFile, $class_ptr ) ) {
 			/*
 			 * This rule should not be applied to test classes (at all).
@@ -169,24 +172,31 @@ final class FileNameSniff extends Sniff {
 
 		$file_name = basename( $file );
 
-		$this->check_filename_is_hyphenated( $file_name );
-
-		if ( true !== $this->strict_file_names ) {
+		// plain file, just check hyphenation.
+		if ( ! $class_ptr && ! $trait_ptr && ! $interface_ptr ) {
+			$this->check_filename_is_hyphenated( $file_name );
 			return ( $this->phpcsFile->numTokens + 1 );
 		}
 
+		// not a plain file, but not strict, just check hyphenation.
+		if ( true !== $this->strict_file_names ) {
+			$this->check_filename_is_hyphenated( $file_name );
+			return ( $this->phpcsFile->numTokens + 1 );
+		}
+
+		// check for "(abstract-)class-" prefix.
 		if ( false !== $class_ptr ) {
 			$this->check_filename_has_class_prefix( $class_ptr, $file_name );
 			return ( $this->phpcsFile->numTokens + 1 );
 		}
 
-		$trait_ptr = $this->phpcsFile->findNext( \T_TRAIT, $stack_ptr );
+		// check for "trait-" prefix.
 		if ( false !== $trait_ptr ) {
 			$this->check_filename_has_trait_prefix( $trait_ptr, $file_name );
 			return ( $this->phpcsFile->numTokens + 1 );
 		}
 
-		$interface_ptr = $this->phpcsFile->findNext( \T_INTERFACE, $stack_ptr );
+		// check for "interface-" prefix.
 		if ( false !== $interface_ptr ) {
 			$this->check_filename_has_interface_prefix( $interface_ptr, $file_name );
 			return ( $this->phpcsFile->numTokens + 1 );

--- a/BigBite/Sniffs/Files/FileNameSniff.php
+++ b/BigBite/Sniffs/Files/FileNameSniff.php
@@ -1,37 +1,165 @@
 <?php
-
 /**
  * BigBite Coding Standards.
  *
- * @package BigBite\phpcs-config
+ * @package BigBiteCS\BigBite
  * @link    https://github.com/bigbite/phpcs-config
  * @license https://opensource.org/licenses/MIT MIT
  */
 
-declare( strict_types = 1 );
-
 namespace BigBiteCS\BigBite\Sniffs\Files;
 
-use WordPressCS\WordPress\Sniffs\Files\FileNameSniff as WPFileNameSniff;
+use PHP_CodeSniffer\Exceptions\RuntimeException;
+use PHPCSUtils\Tokens\Collections;
+use PHPCSUtils\Utils\ObjectDeclarations;
+use PHPCSUtils\Utils\TextStrings;
+use WordPressCS\WordPress\Helpers\IsUnitTestTrait;
+use WordPressCS\WordPress\Sniff;
 
 /**
- * Ensures filenames are kebab-case, and are named appropriately
+ * Ensures filenames are kebab-case, and are named appropriately.
+ *
+ * This is an extension of the WordPress.Files.FileName sniff.
+ * In WPCS v3.0.0, the FileName sniff was marked as final, so
+ * we can no longer extend it. Instead, we have copied the
+ * relevant parts of the sniff here, and made the necessary
+ * changes to account for abstract classes, traits and interfaces.
+ *
+ * Long term, it may be a good idea to check with the WPCS team,
+ * to see if they would be interested in a backported PR to
+ * the core sniff.
  */
-class FileNameSniff extends WPFileNameSniff {
+final class FileNameSniff extends Sniff {
+
+	use IsUnitTestTrait;
+
+	/**
+	 * Regex for the theme specific exceptions.
+	 *
+	 * N.B. This regex currently does not allow for mimetype sublevel only file names,
+	 * such as `plain.php`.
+	 *
+	 * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
+	 * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#custom-taxonomies
+	 * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#custom-post-types
+	 * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#embeds
+	 * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#attachment
+	 * @link https://developer.wordpress.org/themes/template-files-section/partial-and-miscellaneous-template-files/#content-slug-php
+	 * @link https://wphierarchy.com/
+	 * @link https://en.wikipedia.org/wiki/Media_type#Naming
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var string
+	 */
+	const THEME_EXCEPTIONS_REGEX = '`
+		^                    # Anchor to the beginning of the string.
+		(?:
+							 # Template prefixes which can have exceptions.
+			(?:archive|category|content|embed|page|single|tag|taxonomy)
+			-[^\.]+          # These need to be followed by a dash and some chars.
+		|
+			(?:application|audio|example|image|message|model|multipart|text|video) #Top-level mime-types
+			(?:_[^\.]+)?     # Optionally followed by an underscore and a sub-type.
+		)\.(?:php|inc)$      # End in .php (or .inc for the test files) and anchor to the end of the string.
+	`Dx';
+
+	/**
+	 * Whether the codebase being sniffed is a theme.
+	 *
+	 * If true, it will allow for certain typical theme specific exceptions to the filename rules.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var bool
+	 */
+	public $is_theme = false;
+
+	/**
+	 * Whether to apply strict file name rules.
+	 *
+	 * If true, it demands that classes/traits/interfaces are prefixed
+	 * with the appropriate prefix ("type-"), and that the rest of the
+	 * file name reflects the type name.
+	 *
+	 * @since 0.11.0
+	 *
+	 * @var bool
+	 */
+	public $strict_file_names = true;
+
+	/**
+	 * Historical exceptions in WP core to the class name rule.
+	 *
+	 * Note: these files were renamed to comply with the naming conventions in
+	 * WP 6.1.0.
+	 * This means we no longer need to make an exception for them in the
+	 * `check_filename_has_class_prefix()` check, however, we do still need to
+	 * make an exception in the `check_filename_is_hyphenated()` check.
+	 *
+	 * @since 0.11.0
+	 * @since 3.0.0  Property has been renamed from `$class_exceptions` to `$hyphenation_exceptions`,
+	 *
+	 * @var array<string,bool>
+	 */
+	private $hyphenation_exceptions = array(
+		'class.wp-dependencies.php' => true,
+		'class.wp-scripts.php'      => true,
+		'class.wp-styles.php'       => true,
+		'functions.wp-scripts.php'  => true,
+		'functions.wp-styles.php'   => true,
+	);
+
+	/**
+	 * Unit test version of the historical exceptions in WP core.
+	 *
+	 * @since 0.11.0
+	 * @since 3.0.0  Property has been renamed from `$unittest_class_exceptions` to `$unittest_hyphenation_exceptions`,
+	 *
+	 * @var array<string,bool>
+	 */
+	private $unittest_hyphenation_exceptions = array(
+		'class.wp-dependencies.inc' => true,
+		'class.wp-scripts.inc'      => true,
+		'class.wp-styles.inc'       => true,
+		'functions.wp-scripts.inc'  => true,
+		'functions.wp-styles.inc'   => true,
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array<int,int>
+	 */
+	public function register() {
+		if ( \defined( '\PHP_CODESNIFFER_IN_TESTS' ) ) {
+			$this->hyphenation_exceptions += $this->unittest_hyphenation_exceptions;
+		}
+
+		return Collections::phpOpenTags();
+	}
 
 	/**
 	 * Processes this test when one of its tokens is encountered.
 	 *
-	 * @param int $stackPtr The position of the current token in the stack.
+	 * @param int $stack_ptr The position of the current token in the stack.
 	 *
 	 * @return int|void Integer stack pointer to skip forward or void to continue
 	 *                  normal file processing.
 	 */
-	public function process_token( $stackPtr ) {
-		// strip quotes to ensure `stdin_path` passed by IDEs does not include quotes.
-		$file = preg_replace( '`^([\'"])(.*)\1$`Ds', '$2', $this->phpcsFile->getFileName() );
+	public function process_token( $stack_ptr ) {
+		// Usage of `stripQuotes` is to ensure `stdin_path` passed by IDEs does not include quotes.
+		$file = TextStrings::stripQuotes( $this->phpcsFile->getFileName() );
+		if ( 'STDIN' === $file ) {
+			return;
+		}
 
-		if ( 'STDIN' === $file || ! $file ) {
+		$class_ptr = $this->phpcsFile->findNext( \T_CLASS, $stack_ptr );
+		if ( false !== $class_ptr && $this->is_test_class( $this->phpcsFile, $class_ptr ) ) {
+			/*
+			 * This rule should not be applied to test classes (at all).
+			 * @link https://github.com/WordPress/WordPress-Coding-Standards/issues/1995
+			 */
 			return;
 		}
 
@@ -39,33 +167,36 @@ class FileNameSniff extends WPFileNameSniff {
 			return;
 		}
 
-		$fileName = basename( $file );
+		$file_name = basename( $file );
 
-		list( $ext, $file ) = explode( '.', strrev( $fileName ), 2 );
+		$this->check_filename_is_hyphenated( $file_name );
 
-		$expected = $this->kebab( strrev( $file ) ) . '.' . strrev( $ext );
-
-		/*
-		 * Generic check for lowercase hyphenated file names.
-		 */
-		if ( $fileName !== $expected && ( false === $this->is_theme || 1 !== preg_match( self::THEME_EXCEPTIONS_REGEX, $fileName ) ) ) {
-			$this->phpcsFile->addError(
-				'Filenames should be all lowercase with hyphens as word separators. Expected %s, but found %s.',
-				0,
-				'NotHyphenatedLowercase',
-				[ $expected, $fileName ]
-			);
-		}
-
-		unset( $expected );
-
-		if ( true !== $this->strict_class_file_names ) {
+		if ( true !== $this->strict_file_names ) {
 			return ( $this->phpcsFile->numTokens + 1 );
 		}
 
-		$this->check_maybe_class( $stackPtr, $fileName );
-		$this->check_maybe_trait( $stackPtr, $fileName );
-		$this->check_maybe_interface( $stackPtr, $fileName );
+		if ( false !== $class_ptr ) {
+			$this->check_filename_has_class_prefix( $class_ptr, $file_name );
+			return ( $this->phpcsFile->numTokens + 1 );
+		}
+
+		$trait_ptr = $this->phpcsFile->findNext( \T_TRAIT, $stack_ptr );
+		if ( false !== $trait_ptr ) {
+			$this->check_filename_has_trait_prefix( $trait_ptr, $file_name );
+			return ( $this->phpcsFile->numTokens + 1 );
+		}
+
+		$interface_ptr = $this->phpcsFile->findNext( \T_INTERFACE, $stack_ptr );
+		if ( false !== $interface_ptr ) {
+			$this->check_filename_has_interface_prefix( $interface_ptr, $file_name );
+			return ( $this->phpcsFile->numTokens + 1 );
+		}
+
+		$is_wpinc_path = false !== strpos( $file, \DIRECTORY_SEPARATOR . 'wp-includes' . \DIRECTORY_SEPARATOR );
+
+		if ( $is_wpinc_path && false === $class_ptr ) {
+			$this->check_filename_for_template_suffix( $stack_ptr, $file_name );
+		}
 
 		// Only run this sniff once per file, no need to run it again.
 		return ( $this->phpcsFile->numTokens + 1 );
@@ -81,6 +212,7 @@ class FileNameSniff extends WPFileNameSniff {
 			return false;
 		}
 
+		// Respect phpcs:disable comments as long as they are not accompanied by an enable.
 		$i = -1;
 		while ( $i = $this->phpcsFile->findNext( \T_PHPCS_DISABLE, ( $i + 1 ) ) ) {
 			if ( empty( $this->tokens[ $i ]['sniffCodes'] )
@@ -107,116 +239,179 @@ class FileNameSniff extends WPFileNameSniff {
 	}
 
 	/**
+	 * Generic check for lowercase hyphenated file names.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $file_name The name of the current file.
+	 *
+	 * @throws RuntimeException If the file name does not contain an extension.
+	 *
+	 * @return void
+	 */
+	protected function check_filename_is_hyphenated( $file_name ) {
+		$extension = strrchr( $file_name, '.' );
+
+		if ( ! is_string( $extension ) ) {
+			throw new RuntimeException( sprintf( 'File name without extension found: "%s"', $file_name ) );
+		}
+
+		$name     = substr( $file_name, 0, ( strlen( $file_name ) - strlen( $extension ) ) );
+		$expected = $this->kebab( $name ) . $extension;
+
+		if ( $file_name === $expected || isset( $this->hyphenation_exceptions[ $file_name ] ) ) {
+			return;
+		}
+
+		if ( true === $this->is_theme && 1 === preg_match( self::THEME_EXCEPTIONS_REGEX, $file_name ) ) {
+			return;
+		}
+
+		$this->phpcsFile->addError(
+			'Filenames should be all lowercase with hyphens as word separators. Expected %s, but found %s.',
+			0,
+			'NotHyphenatedLowercase',
+			array( $expected, $file_name )
+		);
+	}
+
+	/**
 	 * Check files containing a class for the "class-" prefix,
 	 * and that the rest of the file name reflects the class name.
 	 * Accounts for abstract classes.
 	 *
-	 * @param mixed  $stackPtr the token stack
-	 * @param string $fileName the name of the file
+	 * @param mixed  $class_ptr the token stack.
+	 * @param string $file_name the name of the file.
 	 *
-	 * @return void
+	 * @return bool
 	 */
-	protected function check_maybe_class( $stackPtr, $fileName ) {
-		$has_class = $this->phpcsFile->findNext( \T_CLASS, $stackPtr );
-
-		if ( false === $has_class || false !== $this->is_test_class( $has_class ) ) {
-			return;
-		}
-
-		$is_abstract = $this->phpcsFile->findPrevious( \T_ABSTRACT, $has_class );
-		$class_name  = $this->phpcsFile->getDeclarationName( $has_class );
-
-		if ( is_null( $class_name ) ) {
-			$class_name = 'anonymous';
-		}
-
-		$expected    = 'class-' . $this->kebab( $class_name );
+	protected function check_filename_has_class_prefix( $class_ptr, $file_name ) {
+		$extension   = strrchr( $file_name, '.' );
+		$class_name  = ObjectDeclarations::getName( $this->phpcsFile, $class_ptr );
+		$properties  = ObjectDeclarations::getClassProperties( $this->phpcsFile, $class_ptr );
+		$expected    = 'class-' . $this->kebab( $class_name ) . $extension;
 		$err_message = 'Class file names should be based on the class name with "class-" prepended. Expected %s, but found %s.';
 
-		if ( $is_abstract ) {
+		if ( $properties['is_abstract'] ) {
 			$expected    = 'abstract-' . $expected;
 			$err_message = 'Abstract class file names should be based on the class name with "abstract-class-" prepended. Expected %s, but found %s.';
 		}
 
-		if ( substr( $fileName, 0, -4 ) === $expected ) {
-			return;
+		if ( $file_name === $expected ) {
+			return true;
 		}
 
-		$this->phpcsFile->addError( $err_message, 0, 'InvalidClassFileName', [ $expected . '.php', $fileName ] );
+		$this->phpcsFile->addError( $err_message, 0, 'InvalidClassFileName', array( $expected, $file_name ) );
+
+		return false;
 	}
 
 	/**
 	 * Check files containing a trait for the "trait-" prefix,
 	 * and that the rest of the file name reflects the trait name.
 	 *
-	 * @param mixed  $stackPtr the token stack
-	 * @param string $fileName the name of the file
+	 * @param mixed  $trait_ptr the token stack.
+	 * @param string $file_name the name of the file.
 	 *
-	 * @return void
+	 * @return bool
 	 */
-	protected function check_maybe_trait( $stackPtr, $fileName ) {
-		$has_trait = $this->phpcsFile->findNext( \T_TRAIT, $stackPtr );
+	protected function check_filename_has_trait_prefix( $trait_ptr, $file_name ) {
+		$extension   = strrchr( $file_name, '.' );
+		$trait_name  = ObjectDeclarations::getName( $this->phpcsFile, $trait_ptr );
+		$expected    = 'trait-' . $this->kebab( $trait_name ) . $extension;
+		$err_message = 'Trait file names should be based on the trait name with "trait-" prepended. Expected %s, but found %s.';
 
-		if ( false === $has_trait || false !== $this->is_test_class( $has_trait ) ) {
-			return;
+		if ( $file_name === $expected ) {
+			return true;
 		}
 
-		$trait_name  = $this->phpcsFile->getDeclarationName( $has_trait );
-		$expected    = 'trait-' . $this->kebab( $trait_name );
-		$err_message = 'Trait file names should be based on the class name with "trait-" prepended. Expected %s, but found %s.';
+		$this->phpcsFile->addError( $err_message, 0, 'InvalidTraitFileName', array( $expected, $file_name ) );
 
-		if ( substr( $fileName, 0, -4 ) === $expected ) {
-			return;
-		}
-
-		$this->phpcsFile->addError( $err_message, 0, 'InvalidTraitFileName', [ $expected . '.php', $fileName ] );
+		return false;
 	}
 
 	/**
 	 * Check files containing an interface for the "interface-" prefix,
 	 * and that the rest of the file name reflects the interface name.
 	 *
-	 * @param mixed  $stackPtr the token stack
-	 * @param string $fileName the name of the file
+	 * @param mixed  $interface_ptr the token stack.
+	 * @param string $file_name     the name of the file.
+	 *
+	 * @return bool
+	 */
+	protected function check_filename_has_interface_prefix( $interface_ptr, $file_name ) {
+		$extension      = strrchr( $file_name, '.' );
+		$interface_name = ObjectDeclarations::getName( $this->phpcsFile, $interface_ptr );
+		$expected       = 'interface-' . $this->kebab( $interface_name ) . $extension;
+		$err_message    = 'Interface file names should be based on the interface name with "interface-" prepended. Expected %s, but found %s.';
+
+		if ( $file_name === $expected ) {
+			return true;
+		}
+
+		$this->phpcsFile->addError( $err_message, 0, 'InvalidInterfaceFileName', array( $expected, $file_name ) );
+
+		return false;
+	}
+
+	/**
+	 * Check non-class files in "wp-includes" with a "@subpackage Template" tag for a "-template" suffix.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param int    $stackPtr  Stack pointer to the first PHP open tag in the file.
+	 * @param string $file_name The name of the current file.
 	 *
 	 * @return void
 	 */
-	protected function check_maybe_interface( $stackPtr, $fileName ) {
-		$has_interface = $this->phpcsFile->findNext( \T_INTERFACE, $stackPtr );
-
-		if ( false === $has_interface || false !== $this->is_test_class( $has_interface ) ) {
+	protected function check_filename_for_template_suffix( $stackPtr, $file_name ) {
+		$subpackage_tag = $this->phpcsFile->findNext( \T_DOC_COMMENT_TAG, $stackPtr, null, false, '@subpackage' );
+		if ( false === $subpackage_tag ) {
 			return;
 		}
 
-		$interface_name = $this->phpcsFile->getDeclarationName( $has_interface );
-		$expected       = 'interface-' . $this->kebab( $interface_name );
-		$err_message    = 'Interface file names should be based on the interface name with "interface-" prepended. Expected %s, but found %s.';
-
-		if ( substr( $fileName, 0, -4 ) === $expected ) {
+		$subpackage = $this->phpcsFile->findNext( \T_DOC_COMMENT_STRING, $subpackage_tag );
+		if ( false === $subpackage ) {
 			return;
 		}
 
-		$this->phpcsFile->addError( $err_message, 0, 'InvalidInterfaceFileName', [ $expected . '.php', $fileName ] );
+		$fileName_end = substr( $file_name, -13 );
+
+		if ( ( 'Template' === trim( $this->tokens[ $subpackage ]['content'] )
+			&& $this->tokens[ $subpackage_tag ]['line'] === $this->tokens[ $subpackage ]['line'] )
+			&& ( ( ! \defined( '\PHP_CODESNIFFER_IN_TESTS' ) && '-template.php' !== $fileName_end )
+			|| ( \defined( '\PHP_CODESNIFFER_IN_TESTS' ) && '-template.inc' !== $fileName_end ) )
+		) {
+			$this->phpcsFile->addError(
+				'Files containing template tags should have "-template" appended to the end of the file name. Expected %s, but found %s.',
+				0,
+				'InvalidTemplateTagFileName',
+				array(
+					substr( $file_name, 0, -4 ) . '-template.php',
+					$file_name,
+				)
+			);
+		}
 	}
 
 	/**
 	 * Convert a string to kebab-case
 	 *
-	 * @param string $string the string to texturise
+	 * @param string $filename the string to texturise.
 	 *
 	 * @return string
 	 */
-	protected function kebab( $string = '' ) {
-		$kebab = preg_replace( '/(?>(?!^[A-Z]))([a-z])([A-Z])/', '$1-$2', $string );
+	protected function kebab( $filename = '' ) {
+		$kebab = preg_replace( '`[[:punct:]]`', '-', $filename );
+		$kebab = preg_replace( '/(?>(?!^[A-Z]))([a-z])([A-Z])/', '$1-$2', $filename );
 		$kebab = strtolower( $kebab );
 		$kebab = str_replace( '_', '-', $kebab );
 
-		// allow wordpress to be one word
-		if ( false !== strpos( $string, 'WordPress' ) ) {
+		// allow wordpress to be one word.
+		if ( false !== strpos( $filename, 'WordPress' ) ) {
 			$kebab = str_replace( 'word-press', 'wordpress', $kebab );
 		}
 
 		return $kebab;
 	}
-
 }

--- a/BigBite/Tests/AbstractSniffUnitTest.php
+++ b/BigBite/Tests/AbstractSniffUnitTest.php
@@ -1,8 +1,18 @@
 <?php
+/**
+ * Unit test class for BigBite Coding Standard.
+ *
+ * @package BigBiteCS\BigBite
+ * @link    https://github.com/bigbite/phpcs-config
+ * @license https://opensource.org/licenses/MIT MIT
+ */
 
 namespace BigBiteCS\BigBite\Tests;
 
 use PHP_CodeSniffer\Tests\Standards\AbstractSniffUnitTest as PhpCsAbstractSniffUnitTest;
 
+/**
+ * Unit test class for BigBite Coding Standard.
+ */
 abstract class AbstractSniffUnitTest extends PhpCsAbstractSniffUnitTest {
 }

--- a/BigBite/Tests/Files/FileNameUnitTest.php
+++ b/BigBite/Tests/Files/FileNameUnitTest.php
@@ -44,10 +44,10 @@ final class FileNameUnitTest extends AbstractSniffUnitTest {
 		'class-different-class.inc'                  => 1,
 		'interface-different-interface.inc'          => 1,
 		'trait-different-trait.inc'                  => 1,
-		'AbstractClassMyClass.inc'                   => 2,
-		'ClassMyClass.inc'                           => 2,
-		'InterfaceMyInterface.inc'                   => 2,
-		'TraitMyTrait.inc'                           => 2,
+		'AbstractClassMyClass.inc'                   => 1,
+		'ClassMyClass.inc'                           => 1,
+		'InterfaceMyInterface.inc'                   => 1,
+		'TraitMyTrait.inc'                           => 1,
 
 		// Theme specific exceptions in a non-theme context.
 		'single-my_post_type.inc'                    => 1,

--- a/BigBite/Tests/Files/FileNameUnitTest.php
+++ b/BigBite/Tests/Files/FileNameUnitTest.php
@@ -16,7 +16,7 @@ use BigBiteCS\BigBite\Tests\AbstractSniffUnitTest;
  *
  * @package BigBiteCS\BigBite
  */
-class FileNameUnitTest extends AbstractSniffUnitTest {
+final class FileNameUnitTest extends AbstractSniffUnitTest {
 
 	/**
 	 * Error files with the expected nr of errors.
@@ -121,32 +121,32 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 	/**
 	 * Get a list of all test files to check.
 	 *
-	 * @param string $testFileBase The base path that the unit tests files will have.
+	 * @param string $test_file_base The base path that the unit tests files will have.
 	 *
 	 * @return string[]
 	 */
-	protected function getTestFiles( $testFileBase ) {
+	protected function getTestFiles( $test_file_base ) {
 		$sep        = \DIRECTORY_SEPARATOR;
-		$test_files = glob( dirname( $testFileBase ) . $sep . 'FileNameUnitTests{' . $sep . ',' . $sep . '*' . $sep . '}*.inc', \GLOB_BRACE );
+		$test_files = glob( dirname( $test_file_base ) . $sep . 'FileNameUnitTests{' . $sep . ',' . $sep . '*' . $sep . '}*.inc', \GLOB_BRACE );
 
 		if ( ! empty( $test_files ) ) {
 			return $test_files;
 		}
 
-		return array( $testFileBase . '.inc' );
+		return array( $test_file_base . '.inc' );
 	}
 
 	/**
 	 * Returns the lines where errors should occur.
 	 *
-	 * @param string $testFile The name of the file being tested.
+	 * @param string $test_file The name of the file being tested.
 	 *
 	 * @return array<int,int> <line number> => <number of errors>
 	 */
-	public function getErrorList( $testFile = '' ) {
-		if ( isset( $this->expected_results[ $testFile ] ) ) {
+	public function getErrorList( $test_file = '' ) {
+		if ( isset( $this->expected_results[ $test_file ] ) ) {
 			return array(
-				1 => $this->expected_results[ $testFile ],
+				1 => $this->expected_results[ $test_file ],
 			);
 		}
 
@@ -161,5 +161,4 @@ class FileNameUnitTest extends AbstractSniffUnitTest {
 	public function getWarningList() {
 		return array();
 	}
-
 }

--- a/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/AbstractClassNonStrictClass.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/AbstractClassNonStrictClass.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set BigBite.Files.FileName strict_class_file_names false
+phpcs:set BigBite.Files.FileName strict_file_names false
 
 <?php
 
 abstract class Non_Strict_Class {}
 
-// phpcs:set BigBite.Files.FileName strict_class_file_names true
+// phpcs:set BigBite.Files.FileName strict_file_names true

--- a/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/ClassNonStrictClass.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/ClassNonStrictClass.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set BigBite.Files.FileName strict_class_file_names false
+phpcs:set BigBite.Files.FileName strict_file_names false
 
 <?php
 
 class Non_Strict_Class {}
 
-// phpcs:set BigBite.Files.FileName strict_class_file_names true
+// phpcs:set BigBite.Files.FileName strict_file_names true

--- a/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/InterfaceNonStrictClass.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/InterfaceNonStrictClass.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set BigBite.Files.FileName strict_class_file_names false
+phpcs:set BigBite.Files.FileName strict_file_names false
 
 <?php
 
 interface Non_Strict_Interface {}
 
-// phpcs:set BigBite.Files.FileName strict_class_file_names true
+// phpcs:set BigBite.Files.FileName strict_file_names true

--- a/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/TraitNonStrictClass.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/TraitNonStrictClass.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set BigBite.Files.FileName strict_class_file_names false
+phpcs:set BigBite.Files.FileName strict_file_names false
 
 <?php
 
 trait Non_Strict_Trait {}
 
-// phpcs:set BigBite.Files.FileName strict_class_file_names true
+// phpcs:set BigBite.Files.FileName strict_file_names true

--- a/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-abstract-class.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-abstract-class.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set BigBite.Files.FileName strict_class_file_names false
+phpcs:set BigBite.Files.FileName strict_file_names false
 
 <?php
 
 abstract class Non_Strict_Class {}
 
-// phpcs:set BigBite.Files.FileName strict_class_file_names true
+// phpcs:set BigBite.Files.FileName strict_file_names true

--- a/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-class.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-class.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set BigBite.Files.FileName strict_class_file_names false
+phpcs:set BigBite.Files.FileName strict_file_names false
 
 <?php
 
 class Non_Strict_Class {}
 
-// phpcs:set BigBite.Files.FileName strict_class_file_names true
+// phpcs:set BigBite.Files.FileName strict_file_names true

--- a/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-interface.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-interface.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set BigBite.Files.FileName strict_class_file_names false
+phpcs:set BigBite.Files.FileName strict_file_names false
 
 <?php
 
 interface Non_Strict_Interface {}
 
-// phpcs:set BigBite.Files.FileName strict_class_file_names true
+// phpcs:set BigBite.Files.FileName strict_file_names true

--- a/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-trait.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-trait.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set BigBite.Files.FileName strict_class_file_names false
+phpcs:set BigBite.Files.FileName strict_file_names false
 
 <?php
 
 trait Non_Strict_Trait {}
 
-// phpcs:set BigBite.Files.FileName strict_class_file_names true
+// phpcs:set BigBite.Files.FileName strict_file_names true

--- a/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/unrelated-filename.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/unrelated-filename.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set BigBite.Files.FileName strict_class_file_names false
+phpcs:set BigBite.Files.FileName strict_file_names false
 
 <?php
 
 class My_Class {}
 
-// phpcs:set BigBite.Files.FileName strict_class_file_names true
+// phpcs:set BigBite.Files.FileName strict_file_names true

--- a/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/unrelated-filename2.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/unrelated-filename2.inc
@@ -1,8 +1,8 @@
 <!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
-phpcs:set BigBite.Files.FileName strict_class_file_names false
+phpcs:set BigBite.Files.FileName strict_file_names false
 
 <?php
 
 abstract class My_Class {}
 
-// phpcs:set BigBite.Files.FileName strict_class_file_names true
+// phpcs:set BigBite.Files.FileName strict_file_names true

--- a/BigBite/ruleset.xml
+++ b/BigBite/ruleset.xml
@@ -56,6 +56,8 @@
     <exclude name="Squiz.Commenting.FunctionComment.ThrowsNotCapital" />
     <!-- Don't enforce a period at the end of comments. -->
     <exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
+    <!-- For consistency, allow a blank line before the class closing brace -->
+    <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
     <!-- We have our own file name sniff - WP doesn't account for abstract classes -->
     <exclude name="WordPress.Files.FileName" />
     <!-- Shorthand ternaries can be okay - should be checked at PR review time -->

--- a/BigBite/ruleset.xml
+++ b/BigBite/ruleset.xml
@@ -50,10 +50,6 @@
     <exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
     <!-- Don't enforce a file comment, since we enforce class, method, and function comments. -->
     <exclude name="Squiz.Commenting.FileComment" />
-    <!-- Allow tidier hooks that leverage anonymous functions. -->
-    <exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
-    <exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments" />
-    <exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine" />
     <!-- Be slightly less aggressive about DocBlock formatting. -->
     <exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
     <exclude name="Squiz.Commenting.FunctionComment.ThrowsNoFullStop" />

--- a/BigBite/ruleset.xml
+++ b/BigBite/ruleset.xml
@@ -47,9 +47,8 @@
 
   <rule ref="WordPress">
     <!-- Don't enforce long-form array syntax. -->
-    <exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+    <exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
     <!-- Don't enforce a file comment, since we enforce class, method, and function comments. -->
-    <exclude name="PEAR.Commenting.FileComment" />
     <exclude name="Squiz.Commenting.FileComment" />
     <!-- Allow tidier hooks that leverage anonymous functions. -->
     <exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
@@ -64,18 +63,24 @@
     <!-- We have our own file name sniff - WP doesn't account for abstract classes -->
     <exclude name="WordPress.Files.FileName" />
     <!-- Shorthand ternaries can be okay - should be checked at PR review time -->
-    <exclude name="WordPress.PHP.DisallowShortTernary.Found" />
+    <exclude name="Universal.Operators.DisallowShortTernary.Found" />
     <!-- Don't cause build failures out of spite -->
     <exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
   </rule>
 
-  <rule ref="WordPress-VIP-Go">
-    <!-- Allow usage of static variables outside of classes -->
-    <exclude name="WordPressVIPMinimum.Variables.VariableAnalysis.StaticOutsideClass" />
-  </rule>
+  <rule ref="WordPress-VIP-Go" />
 
-  <!-- Ensure we're consistant with shorthand array syntax. -->
-  <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
+  <!-- Disallow mixed string/int keys in arrays -->
+  <rule ref="Universal.Arrays.MixedArrayKeyTypes" />
+  <!-- Disallow mixed string/int keys in arrays (where the int keys aren't explicitly set) -->
+  <rule ref="Universal.Arrays.MixedKeyedUnkeyedArray" />
+  <!-- Disallow closures longer than 5 (warn) or 8 (error) lines long -->
+  <rule ref="Universal.FunctionDeclarations.NoLongClosures" />
+  <!-- Enforce non-private, non-abstract methods in traits to be declared as final -->
+  <rule ref="Universal.FunctionDeclarations.RequireFinalMethodsInTraits" />
+  <!-- Enforce the use of the boolean && and || operators instead of the logical and/or operators -->
+  <rule ref="Universal.Operators.DisallowLogicalAndOr" />
+
   <!-- Warn about unused function parameters -->
   <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter">
     <!-- Except under circumstances in which they make sense. -->
@@ -135,14 +140,6 @@
   <!-- Normalise whitespace around class properties. -->
   <rule ref="Squiz.WhiteSpace.PropertyLabelSpacing" />
 
-  <!-- Ensure files end in a newline -->
-  <rule ref="PSR2.Files.EndFileNewline" />
-  <!-- Ensure there are no "else if" statements (use "elseif"). -->
-  <rule ref="PSR2.ControlStructures.ElseIfDeclaration" />
-  <!-- Validate switch statements. -->
-  <rule ref="PSR2.ControlStructures.SwitchDeclaration" />
-  <!-- Prevent empty lines between method bodies and closing braces. -->
-  <rule ref="PSR2.Methods.FunctionClosingBrace" />
   <!-- Ensure use statements are correct. -->
   <rule ref="PSR2.Namespaces.UseDeclaration" />
 
@@ -171,12 +168,6 @@
   <rule ref="PSR12.Files.ImportStatement" />
   <!-- Prevent short opening PHP tag. -->
   <rule ref="PSR12.Files.OpenTag" />
-  <!-- Ensure no superfluous whitespace around nullable type hints. -->
-  <rule ref="PSR12.Functions.NullableTypeDeclaration" />
-  <!-- Validate return type hints. -->
-  <rule ref="PSR12.Functions.ReturnTypeDeclaration" />
-  <!-- Enforce shorthand type hints (int/bool, not integer/boolean). -->
-  <rule ref="PSR12.Keywords.ShortFormTypeKeywords" />
   <!-- Prevent overly-enthusiastic use of compound namespaces. -->
   <rule ref="PSR12.Namespaces.CompoundNamespaceDepth" />
   <!-- Normalise whitespace surrounding operators. -->

--- a/BigBite/ruleset.xml
+++ b/BigBite/ruleset.xml
@@ -68,10 +68,6 @@
 
   <rule ref="WordPress-VIP-Go" />
 
-  <!-- Disallow mixed string/int keys in arrays -->
-  <rule ref="Universal.Arrays.MixedArrayKeyTypes" />
-  <!-- Disallow mixed string/int keys in arrays (where the int keys aren't explicitly set) -->
-  <rule ref="Universal.Arrays.MixedKeyedUnkeyedArray" />
   <!-- Disallow closures longer than 5 (warn) or 8 (error) lines long -->
   <rule ref="Universal.FunctionDeclarations.NoLongClosures" />
   <!-- Enforce non-private, non-abstract methods in traits to be declared as final -->

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * BigBite Coding Standard.
  *
@@ -9,6 +8,8 @@
  *   {@link https://github.com/squizlabs/PHP_CodeSniffer/pull/1384}
  * - Load the Composer autoload file.
  * - Automatically limit the testing to the BigBite tests.
+ *
+ * @package BigBiteCS\BigBite
  */
 
 if ( ! defined( 'PHP_CODESNIFFER_IN_TESTS' ) ) {
@@ -54,14 +55,14 @@ for that PHPCS install.
 	die( 1 );
 }
 
-$bigbite_standards = [
+$bigbite_standards = array(
 	'BigBite' => true,
-];
+);
 
 $all_standards   = PHP_CodeSniffer\Util\Standards::getInstalledStandards();
 $all_standards[] = 'Generic';
 
-$ignored_standards = [];
+$ignored_standards = array();
 foreach ( $all_standards as $standard ) {
 	if ( isset( $bigbite_standards[ $standard ] ) === true ) {
 		continue;
@@ -75,6 +76,7 @@ $standards_to_ignore_string = implode( ',', $ignored_standards );
 /*
  * Set the PHPCS_IGNORE_TEST environment variable to ignore tests from other standards.
  */
+// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv
 putenv( "PHPCS_IGNORE_TESTS={$standards_to_ignore_string}" );
 
 // Clean up.

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,16 @@
 {
     "name": "bigbite/phpcs-config",
-    "description": "Big Bite's PHP Coding Standards.",
     "type": "phpcodesniffer-standard",
+    "description": "Big Bite's PHP Coding Standards.",
+	"keywords": ["phpcs", "standards", "static analysis"],
     "license": "MIT",
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
-        "squizlabs/php_codesniffer" : "^3.6.2",
-        "wp-coding-standards/wpcs": "^2.3.0",
-        "automattic/vipwpcs": "^2.3.3",
-        "php": ">=7.2"
+        "squizlabs/php_codesniffer" : "^3.7.2",
+        "wp-coding-standards/wpcs": "^3.0",
+        "automattic/vipwpcs": "dev-develop",
+        "php": ">=7.2",
+        "phpcsstandards/phpcsutils": "^1.0.8"
     },
     "require-dev": {
         "phpcsstandards/phpcsdevtools": "^1.1.0",
@@ -51,7 +53,6 @@
 		"analyse": "Runs PHPStan Static Analysis checks",
         "is-complete": "Checks that all custom Sniffs are accompanied by unit tests",
         "is-complete-strict": "Checks that all custom Sniffs are acommpanied by unit tests and documentation",
-        "install-cs": "Triggers registration of PHPCS rulesets with PHPCS",
         "all-checks": "Runs the scripts 'lint', 'phpcs', 'is-complete', 'test', 'analyse' in that order",
         "all-checks-strict": "Runs the scripts 'lint', 'phpcs', 'is-complete-strict', 'test', 'analyse' in that order"
     },
@@ -73,9 +74,6 @@
         ],
         "is-complete-strict": [
             "@php ./vendor/phpcsstandards/phpcsdevtools/bin/phpcs-check-feature-completeness ./BigBite"
-        ],
-        "install-cs": [
-            "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
         ],
         "all-checks": [
 			"@lint",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "wp-coding-standards/wpcs": "^3.0",
         "automattic/vipwpcs": "^3.0",
         "php": ">=7.2",
-        "phpcsstandards/phpcsutils": "^1.0.8"
+        "phpcsstandards/phpcsutils": "^1.0.8",
+        "phpcsstandards/phpcsextra": "^1.1"
     },
     "require-dev": {
         "phpcsstandards/phpcsdevtools": "^1.1.0",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
         "squizlabs/php_codesniffer" : "^3.7.2",
         "wp-coding-standards/wpcs": "^3.0",
-        "automattic/vipwpcs": "dev-develop",
+        "automattic/vipwpcs": "^3.0",
         "php": ">=7.2",
         "phpcsstandards/phpcsutils": "^1.0.8"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,36 +4,38 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "040af418f3587910a72505bdf7662236",
+    "content-hash": "583c85332bab46083b34cf22a68e261b",
     "packages": [
         {
             "name": "automattic/vipwpcs",
-            "version": "2.3.3",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b"
+                "reference": "64aa799d3d0761115e0747aa5e1fd92afd35f93e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
-                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/64aa799d3d0761115e0747aa5e1fd92afd35f93e",
+                "reference": "64aa799d3d0761115e0747aa5e1fd92afd35f93e",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
                 "php": ">=5.4",
-                "sirbrillig/phpcs-variable-analysis": "^2.11.1",
-                "squizlabs/php_codesniffer": "^3.5.5",
-                "wp-coding-standards/wpcs": "^2.3"
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.17",
+                "squizlabs/php_codesniffer": "^3.7.2",
+                "wp-coding-standards/wpcs": "^3.0"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9",
                 "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
             },
+            "default-branch": true,
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -49,6 +51,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -56,7 +59,7 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2021-09-29T16:20:23+00:00"
+            "time": "2023-08-26T08:01:08+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -134,17 +137,153 @@
             "time": "2022-02-04T12:51:07+00:00"
         },
         {
-            "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.7",
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "ad2b0b57803a48bb3495777bee2a9a13c8e9da53"
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "98bcdbacbda14b1db85f710b1853125726795bbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/ad2b0b57803a48bb3495777bee2a9a13c8e9da53",
-                "reference": "ad2b0b57803a48bb3495777bee2a9a13c8e9da53",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/98bcdbacbda14b1db85f710b1853125726795bbc",
+                "reference": "98bcdbacbda14b1db85f710b1853125726795bbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "time": "2023-08-26T04:46:45+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "time": "2023-07-16T21:39:41+00:00"
+        },
+        {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.11.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/3b71162a6bf0cde2bff1752e40a1788d8273d049",
+                "reference": "3b71162a6bf0cde2bff1752e40a1788d8273d049",
                 "shasum": ""
             },
             "require": {
@@ -152,7 +291,7 @@
                 "squizlabs/php_codesniffer": "^3.5.6"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
                 "phpcsstandards/phpcsdevcs": "^1.1",
                 "phpstan/phpstan": "^1.7",
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
@@ -180,12 +319,16 @@
                 }
             ],
             "description": "A PHPCS sniff to detect problems with variables.",
+            "keywords": [
+                "phpcs",
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2022-08-16T22:19:00+00:00"
+            "time": "2023-08-05T23:46:11+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -246,30 +389,38 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "bb792cb331472b82c5d7f28fb9b8ec2d20f68826"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bb792cb331472b82c5d7f28fb9b8ec2d20f68826",
+                "reference": "bb792cb331472b82c5d7f28fb9b8ec2d20f68826",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -286,6 +437,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -293,22 +445,22 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "time": "2023-08-21T14:28:38+00:00"
         }
     ],
     "packages-dev": [
         {
-            "name": "doctrine/instantiator",
-            "version": "1.4.1",
+            "name": "doctrine/deprecations",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
+                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
                 "shasum": ""
             },
             "require": {
@@ -316,13 +468,60 @@
             },
             "require-dev": {
                 "doctrine/coding-standard": "^9",
+                "phpstan/phpstan": "1.4.10 || 1.10.15",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psalm/plugin-phpunit": "0.18.4",
+                "psr/log": "^1 || ^2 || ^3",
+                "vimeo/psalm": "4.30.0 || 5.12.0"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/v1.1.1"
+            },
+            "time": "2023-06-03T09:27:29+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^0.16 || ^1",
                 "phpstan/phpstan": "^1.4",
                 "phpstan/phpstan-phpunit": "^1",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.22"
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
             "autoload": {
@@ -349,7 +548,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -365,20 +564,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T08:28:38+00:00"
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
             },
             "require": {
@@ -416,7 +615,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
             },
             "funding": [
                 {
@@ -424,7 +623,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T13:19:32+00:00"
+            "time": "2023-03-08T13:26:56+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -831,25 +1030,33 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.6.1",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "77a32518733312af16a44300404e945338981de3"
+                "reference": "3219c6ee25c9ea71e3d9bbaf39c67c9ebd499419"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
-                "reference": "77a32518733312af16a44300404e945338981de3",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/3219c6ee25c9ea71e3d9bbaf39c67c9ebd499419",
+                "reference": "3219c6ee25c9ea71e3d9bbaf39c67c9ebd499419",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.0"
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^1.13"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
-                "psalm/phar": "^4.8"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^9.5",
+                "rector/rector": "^0.13.9",
+                "vimeo/psalm": "^4.25"
             },
             "type": "library",
             "extra": {
@@ -875,33 +1082,34 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.7.3"
             },
-            "time": "2022-03-15T21:29:03+00:00"
+            "time": "2023-08-12T11:01:26+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.15.0",
+            "version": "v1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
+                "reference": "15873c65b207b07765dbc3c95d20fdf4a320cbe2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
-                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/15873c65b207b07765dbc3c95d20fdf4a320cbe2",
+                "reference": "15873c65b207b07765dbc3c95d20fdf4a320cbe2",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.2",
+                "doctrine/instantiator": "^1.2 || ^2.0",
+                "php": "^7.2 || 8.0.* || 8.1.* || 8.2.*",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^6.0 || ^7.0",
+                "phpstan/phpstan": "^1.9",
                 "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
@@ -942,9 +1150,56 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.17.0"
             },
-            "time": "2021-12-08T12:19:24+00:00"
+            "time": "2023-02-02T15:41:36+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.23.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "846ae76eef31c6d7790fac9bc399ecee45160b26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/846ae76eef31c6d7790fac9bc399ecee45160b26",
+                "reference": "846ae76eef31c6d7790fac9bc399ecee45160b26",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^4.15",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.23.1"
+            },
+            "time": "2023-08-03T16:32:59+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -1444,16 +1699,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.3",
+            "version": "3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758"
+                "reference": "1dc7ceb4a24aede938c7af2a9ed1de09609ca770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1071dfcef776a57013124ff35e1fc41ccd294758",
-                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1dc7ceb4a24aede938c7af2a9ed1de09609ca770",
+                "reference": "1dc7ceb4a24aede938c7af2a9ed1de09609ca770",
                 "shasum": ""
             },
             "require": {
@@ -1506,7 +1761,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/3.0.5"
             },
             "funding": [
                 {
@@ -1514,20 +1769,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:04:30+00:00"
+            "time": "2022-09-14T12:31:48+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
+                "reference": "6296a0c086dd0117c1b78b059374d7fcbe7545ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
-                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/6296a0c086dd0117c1b78b059374d7fcbe7545ae",
+                "reference": "6296a0c086dd0117c1b78b059374d7fcbe7545ae",
                 "shasum": ""
             },
             "require": {
@@ -1572,7 +1827,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.4"
             },
             "funding": [
                 {
@@ -1580,7 +1835,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:59:04+00:00"
+            "time": "2023-05-07T05:30:20+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1647,16 +1902,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.4",
+            "version": "3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "0c32ea2e40dbf59de29f3b49bf375176ce7dd8db"
+                "reference": "73a9676f2833b9a7c36968f9d882589cd75511e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0c32ea2e40dbf59de29f3b49bf375176ce7dd8db",
-                "reference": "0c32ea2e40dbf59de29f3b49bf375176ce7dd8db",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/73a9676f2833b9a7c36968f9d882589cd75511e6",
+                "reference": "73a9676f2833b9a7c36968f9d882589cd75511e6",
                 "shasum": ""
             },
             "require": {
@@ -1712,7 +1967,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.4"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.5"
             },
             "funding": [
                 {
@@ -1720,7 +1975,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-11-11T13:51:24+00:00"
+            "time": "2022-09-14T06:00:17+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -2162,7 +2417,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "automattic/vipwpcs": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "27a0132615b4e7219c1ce3a58860261f",
+    "content-hash": "c7b383ec17f3465d49f7c982680ed4ec",
     "packages": [
         {
             "name": "automattic/vipwpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "583c85332bab46083b34cf22a68e261b",
+    "content-hash": "27a0132615b4e7219c1ce3a58860261f",
     "packages": [
         {
             "name": "automattic/vipwpcs",
-            "version": "dev-develop",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "64aa799d3d0761115e0747aa5e1fd92afd35f93e"
+                "reference": "1b8960ebff9ea3eb482258a906ece4d1ee1e25fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/64aa799d3d0761115e0747aa5e1fd92afd35f93e",
-                "reference": "64aa799d3d0761115e0747aa5e1fd92afd35f93e",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/1b8960ebff9ea3eb482258a906ece4d1ee1e25fd",
+                "reference": "1b8960ebff9ea3eb482258a906ece4d1ee1e25fd",
                 "shasum": ""
             },
             "require": {
@@ -35,7 +35,6 @@
                 "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
             },
-            "default-branch": true,
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -59,7 +58,7 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2023-08-26T08:01:08+00:00"
+            "time": "2023-09-05T11:01:05+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -2417,9 +2416,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "automattic/vipwpcs": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -1203,16 +1203,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.32",
+            "version": "1.10.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "c47e47d3ab03137c0e121e77c4d2cb58672f6d44"
+                "reference": "03b1cf9f814ba0863c4e9affea49a4d1ed9a2ed1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c47e47d3ab03137c0e121e77c4d2cb58672f6d44",
-                "reference": "c47e47d3ab03137c0e121e77c4d2cb58672f6d44",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/03b1cf9f814ba0863c4e9affea49a4d1ed9a2ed1",
+                "reference": "03b1cf9f814ba0863c4e9affea49a4d1ed9a2ed1",
                 "shasum": ""
             },
             "require": {
@@ -1261,7 +1261,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-24T21:54:50+00:00"
+            "time": "2023-09-04T12:20:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
## Description
Major release of this ruleset to fully support WPCS v3.0.0, which contains breaking changes.

## Changelog
* Modify the ruleset's PHPCS ruleset to use the ruleset included in WPCS v3.0.0
* Upgrade and reorganise dependencies to reflect changes introduced in WPCS v3.0.0
* Upgrade `BigBite.Files.FileName` sniff to reflect changes introduced in WPCS v3.0.0
* Skip output of `BigBite.Files.FileName.NotHyphenatedLowercase` error if covered by other error codes (fixes #96)
* Introduce several new sniffs - see "Sniff changes" below
* Fixes https://github.com/bigbite/phpcs-config/issues/119

## Types of changes:
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [x] All checks pass when running `composer run all-checks-strict`.


## Sniff changes

For the full list of upstream changes, see the [WPCS release notes](https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/3.0.0) and [VIP WPCS release notes](https://github.com/Automattic/VIP-Coding-Standards/releases/tag/3.0.0)

We have also introduced several new sniffs that have been made available as a result of the incredible work of the WPCS team:

**`Universal.FunctionDeclarations.NoLongClosures`**  
Detects "long" closures and recommends using a named function instead.  
Configured to warn at 5 lines and error at 8 lines.  
This has potential to cause new errors in your projects if you heavily utilise closures.  
This is a good thing, because long closures have always been discouraged by our style guide in a WordPress context.

**`Universal.FunctionDeclarations.RequireFinalMethodsInTraits`**  
Enforces qualified methods (i.e. not abstract) in traits to be declared as final when such methods are not declared as private.

**`Universal.Operators.DisallowLogicalAndOr`**
Enforces the use of boolean operators (`&&`, `||`) instead of logical operators (`and`, `or`).


## Known breaking changes

**`Universal.NamingConventions.NoReservedKeywordParameterNames`**
A new upstream sniff which disallows use of "reserved" keywords as function parameter names (`$list`, $class`, etc.).  

**`Universal.FunctionDeclarations.NoLongClosures`**
A new sniff which disallows the use of "long" closures, in favour of named functions.  

**`Universal.UseStatements.NoUselessAliases`**
Disallows renaming of imports where there is no collision (`use Foo\Bar\Baz as Qux`).  


## Testing this release

To test this release in your project, run the following in terminal:
```shell
composer require --dev bigbite/phpcs-config:dev-release/v2.0.0 --ignore-platform-req=php
```

Then, ensure your `[.]phpcs.xml[.dist]` file references the standard correctly:
```xml
<?xml version="1.0"?>
<ruleset name="My Project" namespace="BigBite">
  <description>PHPCS linting rules for My Project</description>
  <rule ref="./vendor/bigbite/phpcs-config/BigBite" />
</ruleset>
```

Finally, run the following in terminal:
```shell
./vendor/bin/phpcs .
```


