### PR TITLE
Remove PEAR.Commenting.InlineComment sniff

### DIFF
--- a/BigBite/ruleset.xml
+++ b/BigBite/ruleset.xml
@@ -95,8 +95,6 @@
   <!-- Ensure no space after spread operator. -->
   <rule ref="Generic.WhiteSpace.SpreadOperatorSpacingAfter" />
 
-  <!-- Disallow pearl-style comments (#) ... -->
-  <rule ref="PEAR.Commenting.InlineComment" />
   <!-- Enforce wp-style spaces between parens. -->
   <rule ref="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
   <rule ref="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />


### PR DESCRIPTION
## Description
Fixes #65 - Rule duplication (comment style)

This sniff disallows Perl-style inline comments
(# comment), and its fixer replaces the `# ` prefix with `// `. This functionality is entirely replicated by the Squiz.Commenting.InlineComment sniff, which also performs other tasks related to inline comments. Removing the PEAR version prevents the same comment generating two separate error codes.

## Changelog
* Remove PEAR.Commenting.InlineComment sniff

## Types of changes:
- [x] Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] All checks pass when running `composer run all-checks.
