### PR TITLE
Introduce more comprehensive docblock coverage

### DIFF
--- a/BigBite/ruleset.xml
+++ b/BigBite/ruleset.xml
@@ -122,6 +122,8 @@
     <exclude name="Squiz.Commenting.BlockComment.FirstLineIndent" />
     <exclude name="Squiz.Commenting.BlockComment.LineIndent" />
     <exclude name="Squiz.Commenting.BlockComment.LastLineIndent" />
+    <!-- We expect block comments to start with /** (instead of /*). -->
+    <exclude name="Squiz.Commenting.BlockComment.WrongStart" />
   </rule>
   <!-- Check class comments for conformity. -->
   <rule ref="Squiz.Commenting.ClassComment" />

--- a/BigBite/ruleset.xml
+++ b/BigBite/ruleset.xml
@@ -49,17 +49,10 @@
   <!-- Built asset files from Build Tools. -->
   <exclude-pattern>*/dist/*.asset.php</exclude-pattern>
 
-  <rule ref="WordPress">
-    <!-- Don't enforce long-form array syntax. -->
+  <!-- Use all of WP's ruleset, barring docs, and other rules that don't make sense for us. -->
+  <rule ref="WordPress-Extra">
+    <!-- Don't enforce long-form array syntax; we use short arrays exclusively. -->
     <exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
-    <!-- Don't enforce a file comment, since we enforce class, method, and function comments. -->
-    <exclude name="Squiz.Commenting.FileComment" />
-    <!-- Be slightly less aggressive about DocBlock formatting. -->
-    <exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
-    <exclude name="Squiz.Commenting.FunctionComment.ThrowsNoFullStop" />
-    <exclude name="Squiz.Commenting.FunctionComment.ThrowsNotCapital" />
-    <!-- Don't enforce a period at the end of comments. -->
-    <exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
     <!-- For consistency, allow a blank line before the class closing brace -->
     <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
     <!-- We have our own file name sniff - WP doesn't account for abstract classes -->
@@ -70,7 +63,12 @@
     <exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
   </rule>
 
+  <!-- Use all of WP VIP's ruleset. -->
   <rule ref="WordPress-VIP-Go" />
+
+  <!-- ################ -->
+  <!-- Additional rules -->
+  <!-- ################ -->
 
   <!-- Disallow closures longer than 5 (warn) or 8 (error) lines long -->
   <rule ref="Universal.FunctionDeclarations.NoLongClosures" />
@@ -86,6 +84,11 @@
     <exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInExtendedClassBeforeLastUsed" />
     <exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInImplementedInterfaceAfterLastUsed" />
     <exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInImplementedInterfaceBeforeLastUsed" />
+  </rule>
+  <!-- Include documentation sniff from WordPress-Docs -->
+  <rule ref="Generic.Commenting.DocComment">
+    <!-- Allow other tags to come before @param comments - @see, @link, etc. -->
+    <exclude name="Generic.Commenting.DocComment.ParamNotFirst" />
   </rule>
   <!-- Warn when there's todo/fixme notations -->
   <rule ref="Generic.Commenting.Todo" />
@@ -109,6 +112,43 @@
   <!-- Check that the closing braces of scopes are aligned correctly. -->
   <rule ref="PEAR.WhiteSpace.ScopeClosingBrace" />
 
+  <!-- Include documentation sniffs from WordPress-Docs. -->
+  <rule ref="Squiz.Commenting.BlockComment">
+    <!-- We do not like empty lines after block comments. -->
+    <exclude name="Squiz.Commenting.BlockComment.NoEmptyLineAfter" />
+    <!-- Allow for /* translators: ... */ comments. -->
+    <exclude name="Squiz.Commenting.BlockComment.SingleLine" />
+    <!-- Uses spaces for indentation. -->
+    <exclude name="Squiz.Commenting.BlockComment.FirstLineIndent" />
+    <exclude name="Squiz.Commenting.BlockComment.LineIndent" />
+    <exclude name="Squiz.Commenting.BlockComment.LastLineIndent" />
+  </rule>
+  <rule ref="Squiz.Commenting.ClassComment" />
+  <rule ref="Squiz.Commenting.DocCommentAlignment" />
+  <rule ref="Squiz.Commenting.EmptyCatchComment" />
+  <rule ref="Squiz.Commenting.FunctionComment">
+    <!-- We prefer shorthand int/bool over integer/boolean. -->
+    <exclude name="Squiz.Commenting.FunctionComment.IncorrectParamVarName" />
+    <exclude name="Squiz.Commenting.FunctionComment.InvalidReturn" />
+    <!-- Be slightly less aggressive about DocBlock formatting. -->
+    <exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
+    <exclude name="Squiz.Commenting.FunctionComment.ThrowsNoFullStop" />
+    <exclude name="Squiz.Commenting.FunctionComment.ThrowsNotCapital" />
+  </rule>
+  <rule ref="Squiz.Commenting.FunctionCommentThrowTag" />
+  <rule ref="Squiz.Commenting.InlineComment">
+    <!-- Allow inline docblocks. -->
+    <exclude name="Squiz.Commenting.InlineComment.DocBlock" />
+    <!-- Don't enforce a period at the end of comments. -->
+    <exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
+    <!-- Allow "translators:" comments. -->
+    <exclude name="Squiz.Commenting.InlineComment.NotCapital" />
+  </rule>
+  <rule ref="Squiz.Commenting.PostStatementComment" />
+  <rule ref="Squiz.Commenting.VariableComment">
+    <!-- We prefer shorthand int/bool over integer/boolean. -->
+    <exclude name="Squiz.Commenting.VariableComment.IncorrectVarType" />
+  </rule>
   <!-- Force debug output function calls to error. -->
   <rule ref="Squiz.PHP.DiscouragedFunctions">
     <properties>

--- a/BigBite/ruleset.xml
+++ b/BigBite/ruleset.xml
@@ -53,13 +53,13 @@
   <rule ref="WordPress-Extra">
     <!-- Don't enforce long-form array syntax; we use short arrays exclusively. -->
     <exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
-    <!-- For consistency, allow a blank line before the class closing brace -->
+    <!-- For consistency, allow a blank line before the class closing brace. -->
     <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
-    <!-- We have our own file name sniff - WP doesn't account for abstract classes -->
+    <!-- We have our own file name sniff - WP doesn't account for abstract classes. -->
     <exclude name="WordPress.Files.FileName" />
-    <!-- Shorthand ternaries can be okay - should be checked at PR review time -->
+    <!-- Shorthand ternaries can be okay - should be checked at PR review time. -->
     <exclude name="Universal.Operators.DisallowShortTernary.Found" />
-    <!-- Don't cause build failures out of spite -->
+    <!-- There are scenarios where this would cause issues. -->
     <exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
   </rule>
 
@@ -70,14 +70,14 @@
   <!-- Additional rules -->
   <!-- ################ -->
 
-  <!-- Disallow closures longer than 5 (warn) or 8 (error) lines long -->
+  <!-- Disallow closures longer than 5 (warn) or 8 (error) lines long. -->
   <rule ref="Universal.FunctionDeclarations.NoLongClosures" />
-  <!-- Enforce non-private, non-abstract methods in traits to be declared as final -->
+  <!-- Enforce non-private, non-abstract methods in traits to be declared as final. -->
   <rule ref="Universal.FunctionDeclarations.RequireFinalMethodsInTraits" />
-  <!-- Enforce the use of the boolean && and || operators instead of the logical and/or operators -->
+  <!-- Enforce the use of the boolean && and || operators instead of the logical and/or operators. -->
   <rule ref="Universal.Operators.DisallowLogicalAndOr" />
 
-  <!-- Warn about unused function parameters -->
+  <!-- Warn about unused function parameters. -->
   <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter">
     <!-- Except under circumstances in which they make sense. -->
     <exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundBeforeLastUsed" />
@@ -85,7 +85,7 @@
     <exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInImplementedInterfaceAfterLastUsed" />
     <exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundInImplementedInterfaceBeforeLastUsed" />
   </rule>
-  <!-- Include documentation sniff from WordPress-Docs -->
+  <!-- Check block comments for conformity.. -->
   <rule ref="Generic.Commenting.DocComment">
     <!-- Allow other tags to come before @param comments - @see, @link, etc. -->
     <exclude name="Generic.Commenting.DocComment.ParamNotFirst" />
@@ -112,20 +112,24 @@
   <!-- Check that the closing braces of scopes are aligned correctly. -->
   <rule ref="PEAR.WhiteSpace.ScopeClosingBrace" />
 
-  <!-- Include documentation sniffs from WordPress-Docs. -->
+  <!-- Check block comments for conformity. -->
   <rule ref="Squiz.Commenting.BlockComment">
     <!-- We do not like empty lines after block comments. -->
     <exclude name="Squiz.Commenting.BlockComment.NoEmptyLineAfter" />
     <!-- Allow for /* translators: ... */ comments. -->
     <exclude name="Squiz.Commenting.BlockComment.SingleLine" />
-    <!-- Uses spaces for indentation. -->
+    <!-- These sniff codes use spaces for indentation. -->
     <exclude name="Squiz.Commenting.BlockComment.FirstLineIndent" />
     <exclude name="Squiz.Commenting.BlockComment.LineIndent" />
     <exclude name="Squiz.Commenting.BlockComment.LastLineIndent" />
   </rule>
+  <!-- Check class comments for conformity. -->
   <rule ref="Squiz.Commenting.ClassComment" />
+  <!-- Check block comment alignment. -->
   <rule ref="Squiz.Commenting.DocCommentAlignment" />
+  <!-- Enforce explanatory comments for empty catch statements. -->
   <rule ref="Squiz.Commenting.EmptyCatchComment" />
+  <!-- Check function comments for conformity. -->
   <rule ref="Squiz.Commenting.FunctionComment">
     <!-- We prefer shorthand int/bool over integer/boolean. -->
     <exclude name="Squiz.Commenting.FunctionComment.IncorrectParamVarName" />
@@ -135,7 +139,9 @@
     <exclude name="Squiz.Commenting.FunctionComment.ThrowsNoFullStop" />
     <exclude name="Squiz.Commenting.FunctionComment.ThrowsNotCapital" />
   </rule>
+  <!-- Enforce comments for @throws tags. -->
   <rule ref="Squiz.Commenting.FunctionCommentThrowTag" />
+  <!-- Check inline comments for conformity. -->
   <rule ref="Squiz.Commenting.InlineComment">
     <!-- Allow inline docblocks. -->
     <exclude name="Squiz.Commenting.InlineComment.DocBlock" />
@@ -144,7 +150,9 @@
     <!-- Allow "translators:" comments. -->
     <exclude name="Squiz.Commenting.InlineComment.NotCapital" />
   </rule>
+  <!-- Disallow post-statement comments. -->
   <rule ref="Squiz.Commenting.PostStatementComment" />
+  <!-- Check variable comments for conformity. -->
   <rule ref="Squiz.Commenting.VariableComment">
     <!-- We prefer shorthand int/bool over integer/boolean. -->
     <exclude name="Squiz.Commenting.VariableComment.IncorrectVarType" />

--- a/phpcs.xml.dist.sample
+++ b/phpcs.xml.dist.sample
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Example Project" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Example Project" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
   <description>This is an example project</description>
 
   <exclude-pattern>/root/path/to/file.php</exclude-pattern>


### PR DESCRIPTION
Fixes #167

The [`WordPress-Docs` ruleset](https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/WordPress-Docs/ruleset.xml) implements Sniffs that conform to WordPress' documentation standards. However, that ruleset does not conform completely to our coding standards, and it is difficult to override external Sniff customisations in external standards.

So, this PR removes that standard from our ruleset, and implements a set of rules that better conform with our coding standards. The rules remain heavily inspired by WordPress-Docs.

This PR also tidies up some of the comments in our ruleset.

This PR can be tested by running the following in terminal:
```
composer require --dev bigbite/phpcs-config:dev-feat/docs-sniffs
```
followed by
```
./vendor/bin/phpcs .
```