### PR TITLE
Implement new rules for further conformity checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 composer.phar
 .vscode/
 .phpunit.result.cache

--- a/BigBite/ruleset.xml
+++ b/BigBite/ruleset.xml
@@ -53,12 +53,14 @@
   <rule ref="WordPress-Extra">
     <!-- Don't enforce long-form array syntax; we use short arrays exclusively. -->
     <exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
-    <!-- For consistency, allow a blank line before the class closing brace. -->
-    <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
-    <!-- We have our own file name sniff - WP doesn't account for abstract classes. -->
-    <exclude name="WordPress.Files.FileName" />
     <!-- Shorthand ternaries can be okay - should be checked at PR review time. -->
     <exclude name="Universal.Operators.DisallowShortTernary.Found" />
+    <!-- For consistency, allow a blank line before the class closing brace. -->
+    <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
+    <!-- We prefer +=/-= over ++/\-\-. -->
+    <exclude name="Squiz.Operators.IncrementDecrementUsage" />
+    <!-- We have our own file name sniff - WP doesn't account for abstract classes. -->
+    <exclude name="WordPress.Files.FileName" />
     <!-- There are scenarios where this would cause issues. -->
     <exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
   </rule>
@@ -221,4 +223,26 @@
     <!-- Allow a blank line before the first use statement within a class. -->
     <exclude name="PSR12.Traits.UseDeclaration.UseAfterBrace" />
   </rule>
+  <!-- Use statements must be listed A-Z. -->
+  <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses" />
+  <!-- Disallow use of grouping ({}) in use statements. -->
+  <rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse" />
+  <!-- Disallow unused use statements. -->
+  <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses" />
+  <!-- Disallow loose equality operators. -->
+  <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators" />
+  <!-- Prefer +=/-= over ++/\-\-. -->
+  <rule ref="SlevomatCodingStandard.Operators.DisallowIncrementAndDecrementOperators" />
+  <!-- Prefer generic over array style for type hints (e.g. array<int> over int[]). -->
+  <rule ref="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax" />
+  <!-- Prefer shorthand scalar type hints in docblocks. -->
+  <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints" />
+  <!-- Check that type hints are nullable when default value is null. -->
+  <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue" />
+  <!-- Disallow variable variables ($$foo). -->
+  <rule ref="SlevomatCodingStandard.Variables.DisallowVariableVariable" />
+  <!-- Disallow unused variables. -->
+  <rule ref="SlevomatCodingStandard.Variables.UnusedVariable" />
+  <!-- Disallow useless variables. -->
+  <rule ref="SlevomatCodingStandard.Variables.UselessVariable" />
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "automattic/vipwpcs": "^3.0",
         "php": ">=7.2",
         "phpcsstandards/phpcsutils": "^1.0.8",
-        "phpcsstandards/phpcsextra": "^1.1"
+        "phpcsstandards/phpcsextra": "^1.1",
+        "slevomat/coding-standard": "^8.16"
     },
     "require-dev": {
         "phpcsstandards/phpcsdevtools": "^1.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c7154598ab9ac1df073703c752e599c",
+    "content-hash": "44498576dc2492fb5a6fc1dd9ee63539",
     "packages": [
         {
             "name": "automattic/vipwpcs",
@@ -305,6 +305,53 @@
             "time": "2024-05-20T13:34:27+00:00"
         },
         {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "9b30d6fd026b2c132b3985ce6b23bec09ab3aa68"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/9b30d6fd026b2c132b3985ce6b23bec09ab3aa68",
+                "reference": "9b30d6fd026b2c132b3985ce6b23bec09ab3aa68",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.1.0"
+            },
+            "time": "2025-02-19T13:28:12+00:00"
+        },
+        {
             "name": "sirbrillig/phpcs-variable-analysis",
             "version": "v2.11.22",
             "source": {
@@ -360,6 +407,71 @@
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
             "time": "2025-01-06T17:54:24+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "8.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "7748a4282df19daf966fda1d8c60a8aec803c83a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/7748a4282df19daf966fda1d8c60a8aec803c83a",
+                "reference": "7748a4282df19daf966fda1d8c60a8aec803c83a",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpdoc-parser": "^2.1.0",
+                "squizlabs/php_codesniffer": "^3.11.3"
+            },
+            "require-dev": {
+                "phing/phing": "3.0.1",
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpstan/phpstan": "2.1.6",
+                "phpstan/phpstan-deprecation-rules": "2.0.1",
+                "phpstan/phpstan-phpunit": "2.0.4",
+                "phpstan/phpstan-strict-rules": "2.0.3",
+                "phpunit/phpunit": "9.6.8|10.5.45|11.4.4|11.5.9|12.0.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.16.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-02-23T18:12:49+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",


### PR DESCRIPTION
This PR adds several new rules that will help us with common code smells:

- Use statements A-Z
  - must be in alphabetical order
    - `SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses`
- No unused use statements
  - for if a namespace is being imported, but is not referenced
    - `SlevomatCodingStandard.Namespaces.UnusedUses`
- No use statement grouping
  - no `use Namespace\{Sub_NS_One,Sub_NS_Two}\Foo`
    - `SlevomatCodingStandard.Namespaces.DisallowGroupUse`
- Strict equality
  - will shout at you for `==` or `!=`
    - `SlevomatCodingStandard.Operators.DisallowEqualOperators`
- No increment/decrement
  - will shout at you for `$i++` or `$i--` (instead of `$i += 1` or `$i -= 1`)
    - `Squiz.Operators.IncrementDecrementUsage`
    - `SlevomatCodingStandard.Operators.DisallowIncrementAndDecrementOperators`
- Generics for array type hints
  - use `array<int,string>` instead of `string[]`
    - `SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax`
- Shorthand scalars
  - `int` and `bool` instead of `integer` and `boolean` in type hint comments (we already have this for the actual type hints)
    - `SlevomatCodingStandard.TypeHints.LongTypeHints`
- Nullable in type hints
  - will flag when a param has `int $foo = null` but comment type hint is not nullable
    - `SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue`
- No variable variables
  - disallows `$$foo`
    - `SlevomatCodingStandard.Variables.DisallowVariableVariable`
- No unused variables
  - self explanatory
    - `SlevomatCodingStandard.Variables.UnusedVariable`
- No useless variables
  - this will throw when a variable is assigned and then returned
    - `SlevomatCodingStandard.Variables.UselessVariable`
