### PR TITLE
Add support for Enums to filename sniff

### DIFF
--- a/BigBite/Docs/Files/FileNameStandard.xml
+++ b/BigBite/Docs/Files/FileNameStandard.xml
@@ -1,11 +1,12 @@
 <documentation title="File Names">
   <standard>
   <![CDATA[
-  Files containing classes, interfaces, or traits should be prefixed appropriately - prefixed with the type, and then lower-kebab-case matching the name of the type. Examples:
+  Files containing classes, interfaces, traits, or enums should be prefixed appropriately - prefixed with the type, and then lower-kebab-case matching the name of the type. Examples:
   - trait My_Trait {} => trait-my-trait.php
   - interface My_Interface {} => interface-my-interface.php
   - class My_Class {} => class-my-class.php
   - abstract class My_Abstract_Class {} => abstract-class-my-abstract-class.php
+  - enum My_Enum {} => enum-my-enum.php
   ]]>
   </standard>
 </documentation>

--- a/BigBite/Tests/Files/FileNameUnitTest.php
+++ b/BigBite/Tests/Files/FileNameUnitTest.php
@@ -48,6 +48,8 @@ final class FileNameUnitTest extends AbstractSniffUnitTest {
 		'ClassMyClass.inc'                           => 1,
 		'InterfaceMyInterface.inc'                   => 1,
 		'TraitMyTrait.inc'                           => 1,
+		'enum-different-enum.inc'                    => 1,
+		'EnumMyEnum.inc'                             => 1,
 
 		// Theme specific exceptions in a non-theme context.
 		'single-my_post_type.inc'                    => 1,
@@ -62,6 +64,7 @@ final class FileNameUnitTest extends AbstractSniffUnitTest {
 		'ClassNonStrictClass.inc'                    => 1,
 		'InterfaceNonStrictClass.inc'                => 1,
 		'TraitNonStrictClass.inc'                    => 1,
+		'EnumNonStrictEnum.inc'                      => 1,
 
 		/*
 		 * In /FileNameUnitTests/PHPCSAnnotations.

--- a/BigBite/Tests/Files/FileNameUnitTests/EnumMyEnum.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/EnumMyEnum.inc
@@ -1,0 +1,3 @@
+<?php
+
+enum My_Enum {}

--- a/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/EnumNonStrictEnum.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/EnumNonStrictEnum.inc
@@ -1,0 +1,8 @@
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set BigBite.Files.FileName strict_file_names false
+
+<?php
+
+enum Non_Strict_Enum {}
+
+// phpcs:set BigBite.Files.FileName strict_file_names true

--- a/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-enum.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/NonStrictClassNames/non-strict-enum.inc
@@ -1,0 +1,8 @@
+<!-- Annotation has to be on the second line as errors are thrown on line 1 and errors on annotation lines are ignored. -->
+phpcs:set BigBite.Files.FileName strict_file_names false
+
+<?php
+
+enum Non_Strict_Enum {}
+
+// phpcs:set BigBite.Files.FileName strict_file_names true

--- a/BigBite/Tests/Files/FileNameUnitTests/enum-different-enum.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/enum-different-enum.inc
@@ -1,0 +1,3 @@
+<?php
+
+enum Not_My_Enum {}

--- a/BigBite/Tests/Files/FileNameUnitTests/enum-my-enum.inc
+++ b/BigBite/Tests/Files/FileNameUnitTests/enum-my-enum.inc
@@ -1,0 +1,3 @@
+<?php
+
+enum My_Enum {}


### PR DESCRIPTION
## Description
Updates our file name sniff to account for enums correctly.
Enums should follow the same rules as interfaces, classes, and traits:
- one object per file
- file name should be lower-kebab case, and be prefixed with `enum-`

This PR also remove some template checks that came from the original Sniff, but are not required for our purposes.

## Testing steps
```
composer require --dev bigbite/phpcs-config:dev-feat/enum-filenames
```

Create a file called `enum-my-enum.php`:
```php
enum My_Enum {
    case Foo;
}
```

Run
```
./vendor/bin/phpcs .
```

There should be no errors.

Then try:
- renaming the file or renaming the enum
- adding a second enum to the same file

Run `./vendor/bin/phpcs .` after every change.
If the filename isn't exactly the lower-kebab case name of the enum, prefixed with `enum-`, PHPCS should error.

## Types of changes (_if applicable_):
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] All checks pass when running `composer run all-checks.
