### PR TITLE
Implement Sniff to ensure a blank line after an object's opening brace

### DIFF
--- a/BigBite/Docs/Objects/NewLineAfterOpeningBraceStandard.xml
+++ b/BigBite/Docs/Objects/NewLineAfterOpeningBraceStandard.xml
@@ -1,0 +1,25 @@
+<documentation title="New Line After Opening Brace">
+  <standard>
+  <![CDATA[
+  Object structures should contain one blank newline before the content.
+  ]]>
+  </standard>
+  <code_comparison>
+    <code title="Valid: one blank line before content.">
+    <![CDATA[
+interface Foo {<em>
+
+</em> public function bar();
+}
+    ]]>
+    </code>
+    <code title="Invalid: no blank linne before content.">
+    <![CDATA[
+interface Foo {<em>
+</em> public function bar();
+}
+
+    ]]>
+    </code>
+  </code_comparison>
+</documentation>

--- a/BigBite/Sniffs/Objects/NewLineAfterOpeningBraceSniff.php
+++ b/BigBite/Sniffs/Objects/NewLineAfterOpeningBraceSniff.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * BigBite Coding Standards.
+ *
+ * @package BigBiteCS\BigBite
+ * @link    https://github.com/bigbite/phpcs-config
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace BigBiteCS\BigBite\Sniffs\Objects;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Ensures a blank line between the object definition and its first content.
+ */
+final class NewLineAfterOpeningBraceSniff implements Sniff {
+
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @var array<int,string>
+	 */
+	public $supportedTokenizers = array(
+		'PHP',
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array<int,int|string>
+	 */
+	public function register() {
+		return array(
+			\T_CLASS,
+			\T_ENUM,
+			\T_INTERFACE,
+			\T_TRAIT,
+		);
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token
+	 *                                               in the stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		$openingLineNo = $tokens[ $stackPtr ]['line'];
+		$openingBrace  = $tokens[ $stackPtr ]['scope_opener'];
+		$closingBrace  = $tokens[ $stackPtr ]['scope_closer'];
+		$closingLineNo = $tokens[ $closingBrace ]['line'];
+
+		// Other sniffs will handle objects with empty or malformed bodies.
+		if ( $openingLineNo === $closingLineNo || ( $openingLineNo + 1 ) === $closingLineNo ) {
+			return;
+		}
+
+		$nextContent = $phpcsFile->findNext( \T_WHITESPACE, ( $openingBrace + 1 ), null, true );
+
+		// Blank line exists between opening brace and content.
+		if ( ( $tokens[ $openingBrace ]['line'] + 2 ) === $tokens[ $nextContent ]['line'] ) {
+			return;
+		}
+
+		$error = 'There must be exactly one blank line between the %s definition and its first content.';
+		$data  = array( $tokens[ $stackPtr ]['content'] );
+		$fix   = $phpcsFile->addFixableError( $error, $stackPtr, 'NotFound', $data );
+
+		if ( true !== $fix ) {
+			return;
+		}
+
+		$phpcsFile->fixer->beginChangeset();
+		$phpcsFile->fixer->addNewline( $openingBrace );
+		$phpcsFile->fixer->endChangeset();
+	}
+}

--- a/BigBite/Tests/Objects/NewLineAfterOpeningBraceUnitTest.1.inc
+++ b/BigBite/Tests/Objects/NewLineAfterOpeningBraceUnitTest.1.inc
@@ -1,0 +1,20 @@
+<?php
+
+interface FooInterface {
+  public function foo();
+}
+
+trait FooTrait
+{
+  final public foo() {
+  }
+}
+
+enum FooEnum {
+  case Bar;
+}
+
+class FooClass
+{
+  public array $foo = [];
+}

--- a/BigBite/Tests/Objects/NewLineAfterOpeningBraceUnitTest.1.inc.fixed
+++ b/BigBite/Tests/Objects/NewLineAfterOpeningBraceUnitTest.1.inc.fixed
@@ -1,0 +1,24 @@
+<?php
+
+interface FooInterface {
+
+  public function foo();
+}
+
+trait FooTrait
+{
+
+  final public foo() {
+  }
+}
+
+enum FooEnum {
+
+  case Bar;
+}
+
+class FooClass
+{
+
+  public array $foo = [];
+}

--- a/BigBite/Tests/Objects/NewLineAfterOpeningBraceUnitTest.php
+++ b/BigBite/Tests/Objects/NewLineAfterOpeningBraceUnitTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Unit test class for BigBite Coding Standard.
+ *
+ * @package BigBiteCS\BigBite
+ * @link    https://github.com/bigbite/phpcs-config
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace BigBiteCS\BigBite\Tests\Objects;
+
+use BigBiteCS\BigBite\Tests\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the NewLineAfterOpeningBrace sniff.
+ *
+ * @package BigBiteCS\BigBite
+ */
+final class NewLineAfterOpeningBraceUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * A list of tokenizers this sniff supports.
+	 *
+	 * @var array<int,string>
+	 */
+	public $supportedTokenizers = array(
+		'PHP',
+	);
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array<int,int|string>
+	 */
+	public function register() {
+		return array(
+			\T_CLASS,
+			\T_ENUM,
+			\T_INTERFACE,
+			\T_TRAIT,
+		);
+	}
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array<int,int>
+	 */
+	public function getErrorList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'NewLineAfterOpeningBraceUnitTest.1.inc':
+				return array(
+					3  => 1,
+					7  => 1,
+					13 => 1,
+					17 => 1,
+				);
+			default:
+				return array();
+		}
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array<int,int>
+	 */
+	public function getWarningList( $testFile = '' ) {
+		return array();
+	}
+}


### PR DESCRIPTION
## Description

Our coding standards require a blank line between an object (class, enum, interface, trait) definition's opening brace and first content, but this is not enforced by our PHPCS ruleset. This PR addresses that by introducing a new Sniff.

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] All checks pass when running `composer run all-checks.
