### PR TITLE
Add sniff to ban heredocs.

### DIFF
--- a/BigBite/Docs/PHP/HeredocStandard.xml
+++ b/BigBite/Docs/PHP/HeredocStandard.xml
@@ -1,0 +1,29 @@
+<documentation title="Heredoc">
+    <standard>
+    <![CDATA[
+    Heredoc syntax is disallowed.
+    ]]>
+    </standard>
+    <code_comparison>
+        <code title="Valid: Using standard string interpolation or sprintf.">
+        <![CDATA[
+$text = "some $text";
+
+
+$text = sprintf( 'some %s', $text );
+
+
+        ]]>
+        </code>
+        <code title="Invalid: Using heredoc syntax.">
+        <![CDATA[
+$text = <em><<<EOD
+some $text
+EOD</em>;
+$text2 = <em><<<EOL
+some $text
+EOL</em>;
+        ]]>
+        </code>
+    </code_comparison>
+</documentation>

--- a/BigBite/Sniffs/PHP/HeredocSniff.php
+++ b/BigBite/Sniffs/PHP/HeredocSniff.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * BigBite Coding Standards.
+ *
+ * @package BigBiteCS\BigBite
+ * @link    https://github.com/bigbite/phpcs-config
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace BigBiteCS\BigBite\Sniffs\PHP;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Bans the use of heredocs
+ */
+final class HeredocSniff implements Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array<int|int>
+	 */
+	public function register() {
+		return array( T_START_HEREDOC );
+	}
+
+	/**
+	 * Processes this test when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token in the
+	 *                                               stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$error = 'Use of heredoc syntax ("<<<") is not allowed; use standard strings or inline HTML instead';
+		$phpcsFile->addError( $error, $stackPtr, 'NotAllowed' );
+	}
+}

--- a/BigBite/Tests/PHP/HeredocUnitTest.1.inc
+++ b/BigBite/Tests/PHP/HeredocUnitTest.1.inc
@@ -1,0 +1,7 @@
+<?php
+$str = <<<EOL
+Example of a string that
+spans multiple lines
+using heredoc syntax.
+Contains $variable interpolation.
+EOL;

--- a/BigBite/Tests/PHP/HeredocUnitTest.php
+++ b/BigBite/Tests/PHP/HeredocUnitTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * BigBite Coding Standards.
+ *
+ * @package BigBiteCS\BigBite
+ * @link    https://github.com/bigbite/phpcs-config
+ * @license https://opensource.org/licenses/MIT MIT
+ */
+
+namespace BigBiteCS\BigBite\Tests\PHP;
+
+use BigBiteCS\BigBite\Tests\AbstractSniffUnitTest;
+
+/**
+ * Unit test class for the Heredoc sniff.
+ *
+ * @package BigBiteCS\BigBite
+ */
+final class HeredocUnitTest extends AbstractSniffUnitTest {
+
+	/**
+	 * Returns the lines where errors should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of errors that should occur on that line.
+	 *
+	 * @param string $testFile The name of the file being tested.
+	 *
+	 * @return array<int,int>
+	 */
+	public function getErrorList( $testFile = '' ) {
+		switch ( $testFile ) {
+			case 'HeredocUnitTest.1.inc':
+				return array( 2 => 1 );
+			default:
+				return array();
+		}
+	}
+
+	/**
+	 * Returns the lines where warnings should occur.
+	 *
+	 * The key of the array should represent the line number and the value
+	 * should represent the number of warnings that should occur on that line.
+	 *
+	 * @return array<int, int>
+	 */
+	public function getWarningList() {
+		return array();
+	}
+}


### PR DESCRIPTION
Per internal discussion, we have decided to disallow the use of heredocs (nowdocs are okay). This PR introduces a Sniff to that effect.

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] All checks pass when running `composer run all-checks.
