### PR TITLE
Update line length sniff to disregard long parameter type hints

### DIFF
--- a/BigBite/Tests/Commenting/DocCommentLineLengthUnitTest.1.inc
+++ b/BigBite/Tests/Commenting/DocCommentLineLengthUnitTest.1.inc
@@ -33,3 +33,16 @@
                           /**
                           * This is a comment line that should not trigger a warning, nor an error.
                           */
+
+/**
+ * This is a function docblock, and the first line of it is really long, so it should trigger an error.
+ *
+ * However, it also includes a really long parameter type hint,
+ * which should not trigger an error, despite its line length.
+ * Sometimes type hints are just really long.
+ *
+ * @param array<int,array<string,array<int,array<int,int>>>> $reallyLongParamName This is a description of the param.
+ * @param array<int,string>                                  $anotherParamName    This is a description of the param that exceeds the minimum line length even when disregarding the type hint and parameter name from the length calculation.
+ *
+ * @return void
+ */

--- a/BigBite/Tests/Commenting/DocCommentLineLengthUnitTest.1.inc.fixed
+++ b/BigBite/Tests/Commenting/DocCommentLineLengthUnitTest.1.inc.fixed
@@ -35,3 +35,17 @@
                           /**
                           * This is a comment line that should not trigger a warning, nor an error.
                           */
+
+/**
+ * This is a function docblock, and the first line of it is really long, so it should trigger an error.
+ *
+ * However, it also includes a really long parameter type hint,
+ * which should not trigger an error, despite its line length.
+ * Sometimes type hints are just really long.
+ *
+ * @param array<int,array<string,array<int,array<int,int>>>> $reallyLongParamName This is a description of the param.
+ * @param array<int,string>                                  $anotherParamName    This is a description of the param that exceeds the minimum line length even when disregarding the
+ *                                                                                type hint and parameter name from the length calculation.
+ *
+ * @return void
+ */

--- a/BigBite/Tests/Commenting/DocCommentLineLengthUnitTest.php
+++ b/BigBite/Tests/Commenting/DocCommentLineLengthUnitTest.php
@@ -44,7 +44,8 @@ final class DocCommentLineLengthUnitTest extends AbstractSniffUnitTest {
 		switch ( $testFile ) {
 			case 'DocCommentLineLengthUnitTest.1.inc':
 				return array(
-					8 => 1,
+					8  => 1,
+					45 => 1,
 				);
 			case 'DocCommentLineLengthUnitTest.2.inc':
 				return array(
@@ -73,7 +74,8 @@ final class DocCommentLineLengthUnitTest extends AbstractSniffUnitTest {
 		switch ( $testFile ) {
 			case 'DocCommentLineLengthUnitTest.1.inc':
 				return array(
-					4 => 1,
+					4  => 1,
+					38 => 1,
 				);
 			case 'DocCommentLineLengthUnitTest.2.inc':
 				return array(


### PR DESCRIPTION
## Description
The `BigBite.Commenting.DocCommentLineLength` Sniff, which checks whether a comment exceeds an allowed length, did not take into account for long `@param` lines where the parameter type hint is of significant length.
This PR updates the Sniff to disregard the type hint (and parameter name) from its line length calculation. It now only checks the length of the parameter description.


## Types of changes (_if applicable_):
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] All checks pass when running `composer run all-checks.
