### PR TITLE
Update line length sniff to disregard lines containing specific prefixes

### DIFF
--- a/BigBite/Sniffs/Commenting/DocCommentLineLengthSniff.php
+++ b/BigBite/Sniffs/Commenting/DocCommentLineLengthSniff.php
@@ -52,11 +52,13 @@ final class DocCommentLineLengthSniff implements Sniff {
 	/**
 	 * Specific comment prefixes to ignore.
 	 *
+	 * If a comment line begins with any of these prefixes,
+	 * the line length calculations should be skipped for that line.
+	 *
 	 * @var array<int,string>
 	 */
 	public $descriptorsToIgnore = array(
-		'Plugin Name:',
-		'Theme Name:',
+		'Description:',
 	);
 
 	/**
@@ -116,6 +118,12 @@ final class DocCommentLineLengthSniff implements Sniff {
 
 			if ( \T_DOC_COMMENT_STRING !== $tokens[ $i ]['code'] ) {
 				continue;
+			}
+
+			foreach ( $this->descriptorsToIgnore as $ignoreThisPrefix ) {
+				if ( 0 === strpos( $tokens[ $i ]['content'], $ignoreThisPrefix ) ) {
+					continue 2;
+				}
 			}
 
 			$isAParameterDescription = false;

--- a/BigBite/Tests/Commenting/DocCommentLineLengthUnitTest.1.inc
+++ b/BigBite/Tests/Commenting/DocCommentLineLengthUnitTest.1.inc
@@ -17,13 +17,7 @@
  */
 
 /**
- * Plugin Name: Line lengths
- * Description: WordPress plugin/theme comment line lengths are excluded from this sniff.
- */
-
-/**
- * Theme Name: Line lengths
- * Description: WordPress plugin/theme comment line lengths are excluded from this sniff, both soft limit and hard limit.
+ * Description: comment lines that begin with the "Description:" prefix are excluded from this sniff, both soft limit and hard limit.
  */
 
 /**

--- a/BigBite/Tests/Commenting/DocCommentLineLengthUnitTest.1.inc.fixed
+++ b/BigBite/Tests/Commenting/DocCommentLineLengthUnitTest.1.inc.fixed
@@ -19,13 +19,7 @@
  */
 
 /**
- * Plugin Name: Line lengths
- * Description: WordPress plugin/theme comment line lengths are excluded from this sniff.
- */
-
-/**
- * Theme Name: Line lengths
- * Description: WordPress plugin/theme comment line lengths are excluded from this sniff, both soft limit and hard limit.
+ * Description: comment lines that begin with the "Description:" prefix are excluded from this sniff, both soft limit and hard limit.
  */
 
 /**

--- a/BigBite/Tests/Commenting/DocCommentLineLengthUnitTest.php
+++ b/BigBite/Tests/Commenting/DocCommentLineLengthUnitTest.php
@@ -45,7 +45,7 @@ final class DocCommentLineLengthUnitTest extends AbstractSniffUnitTest {
 			case 'DocCommentLineLengthUnitTest.1.inc':
 				return array(
 					8  => 1,
-					45 => 1,
+					39 => 1,
 				);
 			case 'DocCommentLineLengthUnitTest.2.inc':
 				return array(
@@ -75,7 +75,7 @@ final class DocCommentLineLengthUnitTest extends AbstractSniffUnitTest {
 			case 'DocCommentLineLengthUnitTest.1.inc':
 				return array(
 					4  => 1,
-					38 => 1,
+					32 => 1,
 				);
 			case 'DocCommentLineLengthUnitTest.2.inc':
 				return array(


### PR DESCRIPTION
## Description
The `BigBite.Commenting.DocCommentLineLength` Sniff didn't correctly account for comment lines that start with specific prefixes. 
It skipped scanning WP plugin/theme comments completely, where really it should only skip checking the `Description:` line, as that is the most likely to be excessively long.

## Types of changes (_if applicable_):
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] All checks pass when running `composer run all-checks.
