### PR TITLE
Add several new Sniffs from the Universal standard

### DIFF
--- a/BigBite/ruleset.xml
+++ b/BigBite/ruleset.xml
@@ -52,9 +52,9 @@
   <!-- Use all of WP's ruleset, barring docs, and other rules that don't make sense for us. -->
   <rule ref="WordPress-Extra">
     <!-- Don't enforce long-form array syntax; we use short arrays exclusively. -->
-    <exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
+    <exclude name="Universal.Arrays.DisallowShortArraySyntax" />
     <!-- Shorthand ternaries can be okay - should be checked at PR review time. -->
-    <exclude name="Universal.Operators.DisallowShortTernary.Found" />
+    <exclude name="Universal.Operators.DisallowShortTernary" />
     <!-- For consistency, allow a blank line before the class closing brace. -->
     <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
     <!-- We prefer +=/-= over ++/\-\-. -->
@@ -72,10 +72,19 @@
   <!-- Additional rules -->
   <!-- ################ -->
 
+  <!-- Disallow dirname( __FILE__ ) and nested dirname() calls. -->
+  <rule ref="Modernize.FunctionCalls.Dirname" />
+
+  <!-- Disallow mixing integer and string keys for array items. -->
+  <rule ref="Universal.Arrays.MixedArrayKeyTypes" />
+  <!-- Disallow mixing keyed and unkeyed array items. -->
+  <rule ref="Universal.Arrays.MixedKeyedUnkeyedArray" />
   <!-- Disallow closures longer than 5 (warn) or 8 (error) lines long. -->
   <rule ref="Universal.FunctionDeclarations.NoLongClosures" />
   <!-- Enforce non-private, non-abstract methods in traits to be declared as final. -->
   <rule ref="Universal.FunctionDeclarations.RequireFinalMethodsInTraits" />
+  <!-- Enforce alphabetical sorting for extends/implements names. -->
+  <rule ref="Universal.OOStructures.AlphabeticExtendsImplements" />
   <!-- Enforce the use of the boolean && and || operators instead of the logical and/or operators. -->
   <rule ref="Universal.Operators.DisallowLogicalAndOr" />
 


### PR DESCRIPTION
## Description
Adds Sniffs to:
- disallow `dirname( __FILE__ )` calls (use `__DIR__` instead).
- disallow `dirname( dirname( ... ) )` calls (use `dirname( ..., n )` instead, where `n` is the number of directories to traverse.
- disallow mixing integer and string keys for array items.
- disallow mixing keyed and unkeyed array items.
- enforce alphabetical sorting of `extends` and `implements` names.

Also updates a couple of Sniff exclusions to exclude full Sniffs, rather than specific error codes.

## Types of changes (_if applicable_):
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] All checks pass when running `composer run all-checks.
