### PR TITLE
Bump minimum PHP version to 8.2; set PHPStan to level 8

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -24,8 +24,8 @@
 	<!-- Strip the filepaths down to the relevant bit. -->
 	<arg name="basepath" value="."/>
 
-	<!-- Check up to 8 files simultaneously. -->
-	<arg name="parallel" value="8"/>
+	<!-- Check up to 10 files simultaneously. -->
+	<arg name="parallel" value="10"/>
 
 	<!--
 	#############################################################################
@@ -55,19 +55,8 @@
 	</rule>
 
 	<!-- Check code for cross-version PHP compatibility. -->
-	<config name="testVersion" value="5.4-"/>
-	<rule ref="PHPCompatibility">
-		<!-- Exclude PHP constants back-filled by PHPCS. -->
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_finallyFound"/>
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_yieldFound"/>
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_ellipsisFound"/>
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_powFound"/>
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_pow_equalFound"/>
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_spaceshipFound"/>
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_coalesceFound"/>
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_coalesce_equalFound"/>
-		<exclude name="PHPCompatibility.Constants.NewConstants.t_yield_fromFound"/>
-	</rule>
+	<config name="testVersion" value="7.2-"/>
+	<rule ref="PHPCompatibility"/>
 
 	<!-- Enforce PSR1 compatible namespaces. -->
 	<rule ref="PSR1.Classes.ClassDeclaration"/>

--- a/BigBite/Sniffs/Files/FileNameSniff.php
+++ b/BigBite/Sniffs/Files/FileNameSniff.php
@@ -129,7 +129,7 @@ final class FileNameSniff extends Sniff {
 	/**
 	 * Returns an array of tokens this test wants to listen for.
 	 *
-	 * @return array<int,int>
+	 * @return array<int|string,int|string>
 	 */
 	public function register() {
 		if ( \defined( '\PHP_CODESNIFFER_IN_TESTS' ) ) {
@@ -302,9 +302,14 @@ final class FileNameSniff extends Sniff {
 	 * @return bool
 	 */
 	protected function check_filename_has_class_prefix( $class_ptr, $file_name ) {
-		$extension   = strrchr( $file_name, '.' );
-		$class_name  = ObjectDeclarations::getName( $this->phpcsFile, $class_ptr );
-		$properties  = ObjectDeclarations::getClassProperties( $this->phpcsFile, $class_ptr );
+		$extension  = strrchr( $file_name, '.' );
+		$class_name = ObjectDeclarations::getName( $this->phpcsFile, $class_ptr );
+		$properties = ObjectDeclarations::getClassProperties( $this->phpcsFile, $class_ptr );
+
+		if ( null === $class_name ) {
+			return true;
+		}
+
 		$expected    = 'class-' . $this->kebab( $class_name ) . $extension;
 		$err_message = 'Class file names should be based on the class name with "class-" prepended. Expected %s, but found %s.';
 
@@ -332,8 +337,13 @@ final class FileNameSniff extends Sniff {
 	 * @return bool
 	 */
 	protected function check_filename_has_trait_prefix( $trait_ptr, $file_name ) {
-		$extension   = strrchr( $file_name, '.' );
-		$trait_name  = ObjectDeclarations::getName( $this->phpcsFile, $trait_ptr );
+		$extension  = strrchr( $file_name, '.' );
+		$trait_name = ObjectDeclarations::getName( $this->phpcsFile, $trait_ptr );
+
+		if ( null === $trait_name ) {
+			return true;
+		}
+
 		$expected    = 'trait-' . $this->kebab( $trait_name ) . $extension;
 		$err_message = 'Trait file names should be based on the trait name with "trait-" prepended. Expected %s, but found %s.';
 
@@ -358,8 +368,13 @@ final class FileNameSniff extends Sniff {
 	protected function check_filename_has_interface_prefix( $interface_ptr, $file_name ) {
 		$extension      = strrchr( $file_name, '.' );
 		$interface_name = ObjectDeclarations::getName( $this->phpcsFile, $interface_ptr );
-		$expected       = 'interface-' . $this->kebab( $interface_name ) . $extension;
-		$err_message    = 'Interface file names should be based on the interface name with "interface-" prepended. Expected %s, but found %s.';
+
+		if ( null === $interface_name ) {
+			return true;
+		}
+
+		$expected    = 'interface-' . $this->kebab( $interface_name ) . $extension;
+		$err_message = 'Interface file names should be based on the interface name with "interface-" prepended. Expected %s, but found %s.';
 
 		if ( $file_name === $expected ) {
 			return true;
@@ -380,8 +395,13 @@ final class FileNameSniff extends Sniff {
 	 * @return bool
 	 */
 	protected function check_filename_has_enum_prefix( $enum_ptr, $file_name ) {
-		$extension   = strrchr( $file_name, '.' );
-		$enum_name   = ObjectDeclarations::getName( $this->phpcsFile, $enum_ptr );
+		$extension = strrchr( $file_name, '.' );
+		$enum_name = ObjectDeclarations::getName( $this->phpcsFile, $enum_ptr );
+
+		if ( null === $enum_name ) {
+			return true;
+		}
+
 		$expected    = 'enum-' . $this->kebab( $enum_name ) . $extension;
 		$err_message = 'Enum file names should be based on the enum name with "enum-" prepended. Expected %s, but found %s.';
 
@@ -404,6 +424,11 @@ final class FileNameSniff extends Sniff {
 	protected function kebab( $filename = '' ) {
 		$kebab = preg_replace( '`[[:punct:]]`', '-', $filename );
 		$kebab = preg_replace( '/(?>(?!^[A-Z]))([a-z])([A-Z])/', '$1-$2', $filename );
+
+		if ( null === $kebab ) {
+			$kebab = $filename;
+		}
+
 		$kebab = strtolower( $kebab );
 		$kebab = str_replace( '_', '-', $kebab );
 

--- a/BigBite/ruleset.xml
+++ b/BigBite/ruleset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="BigBite" namespace="BigBiteCS\BigBite" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
   <config name="encoding" value="utf-8" />
-  <config name="testVersion" value="7.4-" />
+  <config name="testVersion" value="8.2-" />
 
   <arg name="extensions" value="php" />
   <arg name="parallel" value="75" />

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 7
+  level: 8
   paths:
     - BigBite
   bootstrapFiles:


### PR DESCRIPTION
## Description
This PR:
- sets the ruleset's minimum PHP version to 8.2.
- sets the standard's minimum PHP version to 7.2.
- bumps PHPStan to level 8.


## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] All checks pass when running `composer run all-checks.
