### PR TITLE
Exclude increment/decrement Sniff that conflicts with our standard

### DIFF
--- a/BigBite/ruleset.xml
+++ b/BigBite/ruleset.xml
@@ -55,6 +55,8 @@
     <exclude name="Universal.Arrays.DisallowShortArraySyntax" />
     <!-- Shorthand ternaries can be okay - should be checked at PR review time. -->
     <exclude name="Universal.Operators.DisallowShortTernary" />
+    <!-- We prefer post-increment to pre-increment. -->
+    <exclude name="Universal.Operators.DisallowStandalonePostIncrementDecrement" />
     <!-- For consistency, allow a blank line before the class closing brace. -->
     <exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
     <!-- We prefer +=/-= over ++/\-\-. -->


### PR DESCRIPTION
## Description
The `Universal.Operators.DisallowStandalonePostIncrementDecrement` Sniff from WPCS conflicts with the `SlevomatCodingStandard.Operators.DisallowIncrementAndDecrementOperators` Sniff that adheres to our coding standard of preference for `+=`/`-=` over `++`/`--`.

## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] All checks pass when running `composer run all-checks.
