### PR TITLE
Remove tag restrictions from class comments

### DIFF
--- a/BigBite-Docs/ruleset.xml
+++ b/BigBite-Docs/ruleset.xml
@@ -22,7 +22,9 @@
     <exclude name="Squiz.Commenting.BlockComment.WrongStart" />
   </rule>
   <!-- Check class comments for conformity. -->
-  <rule ref="Squiz.Commenting.ClassComment" />
+  <rule ref="Squiz.Commenting.ClassComment">
+    <exclude name="Squiz.Commenting.ClassComment.TagNotAllowed" />
+  </rule>
   <!-- Check block comment alignment. -->
   <rule ref="Squiz.Commenting.DocCommentAlignment" />
   <!-- Enforce explanatory comments for empty catch statements. -->


### PR DESCRIPTION
## Description
Rather than maintain a list of allowed/disallowed
tags in class comments, we no longer place any
restrictions upon them. This allows us to define
PHPStan types, Phan annotations, etc. without
having to add PHPCS ignores to the comment.


## Types of changes (_if applicable_):
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] All checks pass when running `composer run all-checks.
