### PR TITLE
Fix stringable sniff to account for namespaces

### DIFF
--- a/BigBite/Sniffs/Classes/StringableSniff.php
+++ b/BigBite/Sniffs/Classes/StringableSniff.php
@@ -67,7 +67,12 @@ final class StringableSniff implements Sniff {
 		$interfaces = ObjectDeclarations::findImplementedInterfaceNames( $phpcsFile, $classDecl );
 
 		// we're good - class containing __toString implements the interface.
-		if ( is_array( $interfaces ) && in_array( 'Stringable', $interfaces, true ) ) {
+		if (
+			is_array( $interfaces ) && (
+				in_array( '\\Stringable', $interfaces, true ) ||
+				in_array( 'Stringable', $interfaces, true )
+			)
+		) {
 			return;
 		}
 
@@ -88,7 +93,7 @@ final class StringableSniff implements Sniff {
 			}
 
 			$phpcsFile->fixer->beginChangeset();
-			$phpcsFile->fixer->addContent( $prevToken, ' implements Stringable' );
+			$phpcsFile->fixer->addContent( $prevToken, ' implements \\Stringable' );
 			$phpcsFile->fixer->endChangeset();
 
 			return;
@@ -101,7 +106,7 @@ final class StringableSniff implements Sniff {
 		}
 
 		$phpcsFile->fixer->beginChangeset();
-		$phpcsFile->fixer->addContentBefore( $endOfLine, ' implements Stringable' );
+		$phpcsFile->fixer->addContentBefore( $endOfLine, ' implements \\Stringable' );
 		$phpcsFile->fixer->endChangeset();
 	}
 }

--- a/BigBite/Tests/Classes/StringableUnitTest.1.inc
+++ b/BigBite/Tests/Classes/StringableUnitTest.1.inc
@@ -3,7 +3,7 @@
 class DoesNotImplementToStringMagicMethod {
 }
 
-class CorrectlyImplementsStringable implements Stringable {
+class CorrectlyImplementsStringable implements \Stringable {
   public function __toString(): string {
     return __CLASS__;
   }

--- a/BigBite/Tests/Classes/StringableUnitTest.1.inc.fixed
+++ b/BigBite/Tests/Classes/StringableUnitTest.1.inc.fixed
@@ -3,25 +3,25 @@
 class DoesNotImplementToStringMagicMethod {
 }
 
-class CorrectlyImplementsStringable implements Stringable {
+class CorrectlyImplementsStringable implements \Stringable {
   public function __toString(): string {
     return __CLASS__;
   }
 }
 
-class IncorrectWithWhitespace implements Stringable {
+class IncorrectWithWhitespace implements \Stringable {
   public function __toString(): string {
     return __CLASS__;
   }
 }
 
-class IncorrectWithNoWhitespace implements Stringable{
+class IncorrectWithNoWhitespace implements \Stringable{
   public function __toString(): string {
     return __CLASS__;
   }
 }
 
-class IncorrectWithNewline implements Stringable
+class IncorrectWithNewline implements \Stringable
 {
   public function __toString(): string {
     return __CLASS__;


### PR DESCRIPTION
## Description
Fixes the fixer within the `BigBite.Classes.Stringable` Sniff to prepend the interface name with a backslash, to ensure it references the global namespace in situations where the class being modified is namespaced.

## Types of changes (_if applicable_):
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist (_if applicable_):
- [x] All checks pass when running `composer run all-checks.
